### PR TITLE
Fix outer loop access instances.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${workspaceFolder}/src/game/res"
+            ],
+            "defines": [
+                "_DEBUG"
+            ],
+            "windowsSdkVersion": "10.0.19041.0",
+            "compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.32.31326/bin/Hostx86/x86/cl.exe",
+            "cStandard": "c11",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "windows-msvc-x86"
+        }
+    ],
+    "version": 4
+}

--- a/src/engine/JPEG/JpegFile.cpp
+++ b/src/engine/JPEG/JpegFile.cpp
@@ -1429,7 +1429,7 @@ WORD FAR CJpegFile::SaveDIB(HDIB hDib, LPSTR lpFileName)
 	
 	// Encrypt Data
 	BYTE *encrypt_data;
-	DWORD encrypt_len, i, j;
+	DWORD encrypt_len, i = 0, j = 0;
 	BYTE random_byte[4];
 
 	// Generate Random Byte.
@@ -1808,7 +1808,7 @@ BOOL CJpegFile::EncryptJPEG(HANDLE hDib,			//Handle to DIB
 	HANDLE fh;
 	DWORD loSize, hiSize;
 	BYTE *data_byte;
-	DWORD encrypt_len, i;
+	DWORD encrypt_len;
 
 	// JPEG 파일 읽어오기
 	fh = CreateFile(csJpeg.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -1824,7 +1824,7 @@ BOOL CJpegFile::EncryptJPEG(HANDLE hDib,			//Handle to DIB
 	data_byte = new BYTE[loSize+8];
 
 	srand((unsigned)time( NULL ));
-	for(i = 0; i < 4; i++) data_byte[i] = rand() % 0x100;
+	for(int i = 0; i < 4; i++) data_byte[i] = rand() % 0x100;
 
 	data_byte[4] = 'K';
 	data_byte[5] = 'S';
@@ -1837,7 +1837,7 @@ BOOL CJpegFile::EncryptJPEG(HANDLE hDib,			//Handle to DIB
 	m_r = 1124;
 	// JPEG 파일 Encoding
 	encrypt_len = loSize+8;
-	for(i = 0; i < encrypt_len; i++)
+	for(int i = 0; i < encrypt_len; i++)
 	{
 		data_byte[i] = Encrypt(data_byte[i]);
 	}
@@ -1866,7 +1866,7 @@ BOOL CJpegFile::DecryptJPEG(std::string csJpeg)
 	HANDLE hSrc, hDst;
 	BYTE *dst_data, *src_data;
 	DWORD dst_len, src_len, src_hlen;
-	DWORD result_len, i, j;
+	DWORD result_len;
 
 	int rfv = csJpeg.rfind('\\');
 	szDstpath = csJpeg;
@@ -1907,13 +1907,13 @@ BOOL CJpegFile::DecryptJPEG(std::string csJpeg)
 	ReadFile(hSrc, (LPVOID)src_data, src_len, &result_len, NULL);
 
 	m_r = 1124;
-	for(i = 0; i < 4; i++)
+	for(int i = 0; i < 4; i++)
 	{
 		Decrypt(src_data[i]);
 	}
 
 	BYTE magic[4];
-	for(i = 4; i < 8; i++)
+	for(int i = 4; i < 8; i++)
 	{
 		magic[i-4] = Decrypt(src_data[i]);
 	}
@@ -1931,7 +1931,7 @@ BOOL CJpegFile::DecryptJPEG(std::string csJpeg)
 		return FALSE;
 	}
 
-	for(j = 0; i < src_len; i++, j++)
+	for(int i = 8, j = 0; i < src_len; i++, j++)
 	{
 		dst_data[j] = Decrypt(src_data[i]);
 	}
@@ -1955,7 +1955,7 @@ BOOL CJpegFile::SaveFromDecryptToJpeg(std::string csKsc, std::string csJpeg)
 	HANDLE hSrc, hDst;
 	BYTE *dst_data, *src_data;
 	DWORD dst_len, src_len, src_hlen;
-	DWORD result_len, i, j;
+	DWORD result_len;
 
 	hSrc = CreateFile((LPCTSTR)csKsc.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 	if(hSrc == INVALID_HANDLE_VALUE)
@@ -1984,11 +1984,11 @@ BOOL CJpegFile::SaveFromDecryptToJpeg(std::string csKsc, std::string csJpeg)
 	ReadFile(hSrc, (LPVOID)src_data, src_len, &result_len, NULL);
 
 	m_r = 1124;
-	for(i = 0; i < 8; i++)
+	for(int i = 0; i < 8; i++)
 	{
 		Decrypt(src_data[i]);
 	}
-	for(j = 0; i < src_len; i++, j++)
+	for(int i = 8, j = 0; i < src_len; i++, j++)
 	{
 		dst_data[j] = Decrypt(src_data[i]);
 	}

--- a/src/engine/N3Base/DFont.cpp
+++ b/src/engine/N3Base/DFont.cpp
@@ -711,7 +711,6 @@ void CDFont::Make3DVertex(const int iFontHeight, const std::string& szText, DWOR
 		if (fMaxY < (-fBottom)) fMaxY = (-fBottom);
 	}
 
-	int i;
 	if (dwFlags & D3DFONT_CENTERED)	// 가운데 정렬이면 vertex좌표를 가운데로 계산해서 고쳐넣기
 	{
 		// 제일 긴 줄 찾기..
@@ -742,7 +741,7 @@ void CDFont::Make3DVertex(const int iFontHeight, const std::string& szText, DWOR
 			}
 			__ASSERT(fCX>0.0f, "??");
 			float fDiffX = -fCX/2.0f;
-			for (i=iCount; i<iCount+iContinueCount; ++i)
+			for (int i=iCount; i<iCount+iContinueCount; ++i)
 			{
 				for (int j=0; j<6; ++j)
 					TempVertices[i*6+j].x += fDiffX;
@@ -756,7 +755,7 @@ void CDFont::Make3DVertex(const int iFontHeight, const std::string& szText, DWOR
 	m_pVB->Lock( 0, 0, (VOID**)&pVertices, 0 );
 
 	iCount = dwNumTriangles*3;
-	for (i=0; i<iCount; ++i)
+	for (int i=0; i<iCount; ++i)
 	{
 		TempVertices[i].x /= ((float)m_dwFontHeight);			// 일정 크기로 줄이기
 		TempVertices[i].y /= ((float)m_dwFontHeight);			// 일정 크기로 줄이기
@@ -793,11 +792,11 @@ HRESULT CDFont::DrawText( FLOAT sx, FLOAT sy, DWORD dwColor, DWORD dwFlags, FLOA
 //		m_pVB->Lock( 0, 0, (VOID**)&pVertices, D3DLOCK_NOSYSLOCK );
 		m_pVB->Lock( 0, 0, (VOID**)&pVertices, 0);
 
-		int i, iVC = m_iPrimitiveCount*3;
+		int iVC = m_iPrimitiveCount*3;
 		if (fabs(vDiff.x)>0.5f)
 		{
 			m_PrevLeftTop.x = sx;
-			for (i=0; i<iVC; ++i)
+			for (int i=0; i<iVC; ++i)
 			{
 				pVertices[i].x += vDiff.x;
 			}
@@ -806,7 +805,7 @@ HRESULT CDFont::DrawText( FLOAT sx, FLOAT sy, DWORD dwColor, DWORD dwFlags, FLOA
 		if (fabs(vDiff.y)>0.5f)
 		{
 			m_PrevLeftTop.y = sy;
-			for (i=0; i<iVC; ++i)
+			for (int i=0; i<iVC; ++i)
 			{
 				pVertices[i].y += vDiff.y;
 			}
@@ -816,7 +815,7 @@ HRESULT CDFont::DrawText( FLOAT sx, FLOAT sy, DWORD dwColor, DWORD dwFlags, FLOA
 		{
 			m_dwFontColor = dwColor;
 			m_PrevLeftTop.y = sy;
-			for (i=0; i<iVC; ++i)
+			for (int i=0; i<iVC; ++i)
 			{
 				pVertices[i].color = m_dwFontColor;
 			}
@@ -824,7 +823,7 @@ HRESULT CDFont::DrawText( FLOAT sx, FLOAT sy, DWORD dwColor, DWORD dwFlags, FLOA
 
 //		if (fZ != 1.0f) // Z값이 1.0f 가 들어오지 않으면 바꾸어준다.
 //		{
-//			for (i=0; i<iVC; ++i)
+//			for (int i=0; i<iVC; ++i)
 //			{
 //				pVertices[i].z = fZ;
 //			}
@@ -936,8 +935,8 @@ HRESULT CDFont::DrawText3D(DWORD dwColor, DWORD dwFlags )
 		m_pVB->Lock( 0, 0, (VOID**)&pVertices, 0 );
 
 		m_dwFontColor = dwColor;
-		int i, iVC = m_iPrimitiveCount*3;
-		for (i=0; i<iVC; ++i)
+		int iVC = m_iPrimitiveCount*3;
+		for (int i=0; i<iVC; ++i)
 		{
 			pVertices[i].color = m_dwFontColor;
 		}
@@ -1053,8 +1052,8 @@ HRESULT	CDFont::SetFontColor(DWORD dwColor)
 			__VertexTransformed* pVertices;
 			if (FAILED(hr = m_pVB->Lock( 0, 0, (VOID**)&pVertices, 0 ))) return hr;
 			m_dwFontColor = dwColor;
-			int i, iVC = m_iPrimitiveCount*3;
-			for (i=0; i<iVC; ++i)
+			int iVC = m_iPrimitiveCount*3;
+			for (int i=0; i<iVC; ++i)
 			{
 				pVertices[i].color = m_dwFontColor;
 			}
@@ -1065,8 +1064,8 @@ HRESULT	CDFont::SetFontColor(DWORD dwColor)
 			__VertexXyzColorT1* pVertices;
 			if (FAILED(hr = m_pVB->Lock( 0, 0, (VOID**)&pVertices, 0 ))) return hr;
 			m_dwFontColor = dwColor;
-			int i, iVC = m_iPrimitiveCount*3;
-			for (i=0; i<iVC; ++i)
+			int iVC = m_iPrimitiveCount*3;
+			for (int i=0; i<iVC; ++i)
 			{
 				pVertices[i].color = m_dwFontColor;
 			}
@@ -1101,11 +1100,11 @@ void CDFont::AddToAlphaManager(DWORD dwColor, float fDist, __Matrix44& mtxWorld,
 	//		m_pVB->Lock( 0, 0, (VOID**)&pVertices, D3DLOCK_NOSYSLOCK );
 			m_pVB->Lock( 0, 0, (VOID**)&pVertices, 0);
 
-			int i, iVC = m_iPrimitiveCount*3;
+			int iVC = m_iPrimitiveCount*3;
 			if (fabs(vDiff.x)>0.5f)
 			{
 				m_PrevLeftTop.x = mtxWorld._41;
-				for (i=0; i<iVC; ++i)
+				for (int i=0; i<iVC; ++i)
 				{
 					pVertices[i].x += vDiff.x;
 				}
@@ -1114,7 +1113,7 @@ void CDFont::AddToAlphaManager(DWORD dwColor, float fDist, __Matrix44& mtxWorld,
 			if (fabs(vDiff.y)>0.5f)
 			{
 				m_PrevLeftTop.y = mtxWorld._42;
-				for (i=0; i<iVC; ++i)
+				for (int i=0; i<iVC; ++i)
 				{
 					pVertices[i].y += vDiff.y;
 				}
@@ -1124,7 +1123,7 @@ void CDFont::AddToAlphaManager(DWORD dwColor, float fDist, __Matrix44& mtxWorld,
 			{
 				m_dwFontColor = dwColor;
 				m_PrevLeftTop.y = mtxWorld._42;
-				for (i=0; i<iVC; ++i)
+				for (int i=0; i<iVC; ++i)
 				{
 					pVertices[i].color = m_dwFontColor;
 				}
@@ -1132,7 +1131,7 @@ void CDFont::AddToAlphaManager(DWORD dwColor, float fDist, __Matrix44& mtxWorld,
 
 //			if (fZ != 1.0f) // Z값이 1.0f 가 들어오지 않으면 바꾸어준다.
 //			{
-//				for (i=0; i<iVC; ++i)
+//				for (int i=0; i<iVC; ++i)
 //				{
 //					pVertices[i].z = fZ;
 //				}

--- a/src/engine/N3Base/JPEG.CPP
+++ b/src/engine/N3Base/JPEG.CPP
@@ -19,20 +19,17 @@
 
 CJpeg::CJpeg()
 {	
-	int i;
 	m_pData = NULL;
-	for(i=0; i<20; i++)
+	for(int i=0; i<20; i++)
 		TbH[i].Flag = FALSE;
 }
 
 CJpeg::~CJpeg()
 {
-	int i;
-
 	if(m_pData != NULL)
 		delete [] m_pData;	
 
-	for(i=0; i<20; i++)
+	for(int i=0; i<20; i++)
 		if(TbH[i].Flag)
 		{
 			delete [] TbH[i].HUFFCODE;
@@ -205,13 +202,12 @@ void CJpeg::FindSOF()
 {
 	if((m_pBuf[m_Index] == 0xff)&&(m_pBuf[m_Index + 1] == 0xc0))
 	{
-		int i;
 		WORD SegSize = m_pBuf[m_Index + 2] * 256 + m_pBuf[m_Index + 3];
 		FrameHeader.Y = m_pBuf[m_Index + 5] * 256 + m_pBuf[m_Index + 6];
 		FrameHeader.X = m_pBuf[m_Index + 7] * 256 + m_pBuf[m_Index + 8];
 		FrameHeader.Nf = m_pBuf[m_Index + 9];
 		
-		for(i=0; i<FrameHeader.Nf; i++)
+		for(int i=0; i<FrameHeader.Nf; i++)
 		{
 			FrameHeader.C[i] = m_pBuf[m_Index + 10 + 3*i];
 			FrameHeader.H[i] = m_pBuf[m_Index + 11 + 3*i] >> 4;
@@ -245,10 +241,9 @@ void CJpeg::FindSOS()
 {
 	if((m_pBuf[m_Index] == 0xff)&&(m_pBuf[m_Index + 1] == 0xda))
 	{
-		int i;		
 		WORD SegSize = m_pBuf[m_Index + 2] * 256 + m_pBuf[m_Index + 3];
 		ScanHeader.Ns = m_pBuf[m_Index + 4];
-		for(i=0; i<ScanHeader.Ns; i++)
+		for(int i=0; i<ScanHeader.Ns; i++)
 		{
 			ScanHeader.Cs[i] = m_pBuf[m_Index + 5 + i*2];
 			ScanHeader.Td[i] = m_pBuf[m_Index + 6 + i*2] >> 4;
@@ -264,7 +259,7 @@ void CJpeg::FindSOS()
 
 		// 최대 Sampling Factor 구함 //
 		Hmax = Vmax = 0;
-		for(i=0; i<FrameHeader.Nf; i++)
+		for(int i=0; i<FrameHeader.Nf; i++)
 		{
 			if(FrameHeader.H[i] > Hmax)
 				Hmax = FrameHeader.H[i];
@@ -317,16 +312,16 @@ BYTE CJpeg::NextByte()
 
 BYTE CJpeg::hDecode(int Th)
 {
-	int i = 1, j;
 	WORD CODE = NextBit();
 	BYTE Value;	
 
+	int i = 1;
 	while((CODE > TbH[Th].MAXCODE[i])||(TbH[Th].MAXCODE[i] == 65535))
 	{
 		i++;
 		CODE = (CODE << 1) + NextBit();
 	}
-	j = TbH[Th].VALPTR[i];
+	int j = TbH[Th].VALPTR[i];
 	j = j + CODE - TbH[Th].MINCODE[i];
 
 	Value = TbH[Th].HUFFVAL[j];
@@ -400,7 +395,6 @@ void CJpeg::DecodeAC(int Th)
 
 void CJpeg::DecodeDU(int N) // N = Component ID 0/1/2
 {	
-	int i;
 	short *pos;
 
 	DecodeDC(ScanHeader.Td[N]);
@@ -412,7 +406,7 @@ void CJpeg::DecodeDU(int N) // N = Component ID 0/1/2
 
 	// Dequantization //
 	pos = ZZ;
-	for(i=0; i<64; i++)
+	for(int i=0; i<64; i++)
 	{
 		*pos = *pos * TbQ[FrameHeader.Tq[N]].Q[i];
 		pos++;
@@ -426,7 +420,7 @@ void CJpeg::DecodeDU(int N) // N = Component ID 0/1/2
 	
 	// Level Shifting  & Correct Error //	
 	pos = ZZ;
-	for(i=0; i<64; i++)
+	for(int i=0; i<64; i++)
 	{
 		*pos = *pos + 128;
 		
@@ -454,11 +448,10 @@ void CJpeg::Zigzag()
 	
 	short Temp[64];
 	memcpy(Temp, ZZ, 64 * sizeof(short));
-	int i, j, idx;
-	for(i=0; i<8; i++)
-		for(j=0; j<8; j++)
+	for(int i=0; i<8; i++)
+		for(int j=0; j<8; j++)
 		{
-			idx = (i<<3)+j;
+			int idx = (i<<3)+j;
 			ZZ[idx] = Temp[Index[idx]];
 		}
 }
@@ -523,34 +516,33 @@ void CJpeg::IDCT()
 
 void CJpeg::DecodeMCU(int mx, int my)
 {
-	int i, j, k, l, m, n, o;
 	int Ns = ScanHeader.Ns;
 	int H, V, Rh, Rv;
 	int mWidth = Hmax * 8, mHeight = Vmax * 8;	
 	int bWidth = FrameHeader.X * Ns, bHeight = FrameHeader.Y;
 	int idx1, idx2, idx3;
 	
-	for(k=0; k<Ns; k++)
+	for(int k=0; k<Ns; k++)
 	{
 		H = FrameHeader.H[k];
 		V = FrameHeader.V[k];		
 		Rh = Hmax / H;
 		Rv = Vmax / V;
 
-		for(l=0; l<V; l++)
+		for(int l=0; l<V; l++)
 		{
-			for(m=0; m<H; m++)
+			for(int m=0; m<H; m++)
 			{
 				DecodeDU(k);
-				for(i=0; i<8; i++)
+				for(int i=0; i<8; i++)
 				{
-					for(j=0; j<8; j++)
+					for(int j=0; j<8; j++)
 					{
 						idx1 = ((l<<3)+i)*Rv;
 						idx2 = ((m<<3)+j)*Rh;
-						for(n = 0; n<Rv; n++)
+						for(int n = 0; n<Rv; n++)
 						{
-							for(o = 0; o<Rh; o++)
+							for(int o = 0; o<Rh; o++)
 							{
 								MCU[(idx1+n) * mWidth + (idx2+o)].C[k] = (BYTE)ZZ[(i<<3)+j];
 							}
@@ -560,13 +552,13 @@ void CJpeg::DecodeMCU(int mx, int my)
 			}		
 		}
 		
-		for(i=0; i<mHeight; i++)
-			for(j=0; j<mWidth; j++)
+		for(int i=0; i<mHeight; i++)
+			for(int j=0; j<mWidth; j++)
 			{
 				idx1 = my * mHeight + i;
 				idx2 = mx * mWidth + j;
 				idx3 = i * mWidth + j;
-				for(n=0; n<Ns; n++)
+				for(int n=0; n<Ns; n++)
 					m_pData[(idx1)*bWidth+((idx2)*Ns + n)] = MCU[idx3].C[n];
 			}
 	}
@@ -577,7 +569,6 @@ void CJpeg::Decode()
 	int Ns = ScanHeader.Ns;	
 	int mx = FrameHeader.X / 8 / Hmax;
 	int my = FrameHeader.Y / 8 / Vmax;	
-	int i, j, k;		
 	
 	cnt = 0;	
 
@@ -586,7 +577,7 @@ void CJpeg::Decode()
 
 	m_pData = new BYTE[FrameHeader.X * FrameHeader.Y * 3];
 
-	for(i=0; i<Ns; i++)
+	for(int i=0; i<Ns; i++)
 		PrevDC[i] = 0;
 
 	MCU = new SET[Vmax * Hmax * 64];
@@ -597,8 +588,8 @@ void CJpeg::Decode()
 	// 실질적인 Decoding Procedure //
 	int Count = 0;///
 	
-	for(i=0; i<my; i++)
-		for(j=0; j<mx; j++)
+	for(int i=0; i<my; i++)
+		for(int j=0; j<mx; j++)
 		{			
 			DecodeMCU(j, i);
 			Count++;
@@ -609,7 +600,7 @@ void CJpeg::Decode()
 				{
 					cnt = 0;
 					pByte = pByte + 2;
-					for(k=0; k<3; k++)
+					for(int k=0; k<3; k++)
 						PrevDC[k] = 0;
 				}				
 			}
@@ -637,7 +628,6 @@ int CJpeg::GetHeight()
 
 void CJpeg::ConvertYUV2RGB()
 {
-	int i, j;
 	int Width = GetWidth();
 	int Height = GetHeight();
 	int Size = Width * Height * ScanHeader.Ns;
@@ -649,8 +639,8 @@ void CJpeg::ConvertYUV2RGB()
 	
 	memcpy(pos, pTemp, Size);
 
-	for(i=0; i<Height; i++)
-		for(j=0; j<Width; j++)
+	for(int i=0; i<Height; i++)
+		for(int j=0; j<Width; j++)
 		{
 			Y = *pos;pos++;
 			
@@ -686,7 +676,7 @@ void CJpeg::ConvertYUV2RGB()
 	{
 		BYTE *pBuf2 = new BYTE [RealBMPWidth  * m_rHeight];
 
-		for(i=0; i<m_rHeight; i++)
+		for(int i=0; i<m_rHeight; i++)
 		{
 			memcpy(&pBuf2[i*RealBMPWidth], &m_pData[i*Width*3], RealBMPWidth);
 		}
@@ -702,7 +692,7 @@ void CJpeg::ConvertYUV2RGB()
 
 	// Flip for BMP Structure //
 	BYTE *pLine = new BYTE[RealBMPWidth];
-	for(i=0; i<m_rHeight/2; i++)
+	for(int i=0; i<m_rHeight/2; i++)
 	{
 		pTemp = &m_pData[i*RealBMPWidth];
 		memcpy(pLine, pTemp, RealBMPWidth);
@@ -728,10 +718,8 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	if(Height % 8 != 0)
 		bHeight = (Height/8 + 1)*8; // bHeight 는 8의 배수로 만든 높이
 
-	int i, j, k;
-
 	// Huffman Table 초기화 //
-	for(i=0; i<20; i++)
+	for(int i=0; i<20; i++)
 	{
 		if(TbH[i].Flag)
 		{
@@ -760,7 +748,7 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	memset(m_pData, 0, (bWidth * 3) * bHeight); // 0으로 초기화 //
 
 	// 8의 배수에 맞도록 버퍼를 만들어서 원래 이미지를 복사합니다 //
-	for(i=0; i<Height; i++)
+	for(int i=0; i<Height; i++)
 		memcpy(&m_pData[i*(bWidth*3)], &pp[i*BMPWidth], BMPWidth);
 
 	// RGB Color를 YCbCr Color로 변환합니다. //
@@ -768,10 +756,10 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	float y, cb, cr;
 	BYTE *pos;	
 
-	for(i=0; i<Height; i++)
+	for(int i=0; i<Height; i++)
 	{
 		pos = &m_pData[i*(bWidth*3)];
-		for(j=0; j<Width; j++)
+		for(int j=0; j<Width; j++)
 		{
 			B = (float)*pos;
 			G = (float)*(pos+1);
@@ -810,9 +798,9 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 
 	
 	// Level Shifting -128 //
-	for(i=0; i<Height; i++)
+	for(int i=0; i<Height; i++)
 	{
-		for(j=0; j<Width; j++)
+		for(int j=0; j<Width; j++)
 		{
 			idx1 = i*bWidth+j;
 			idx2 = i*(bWidth*3)+j*3;
@@ -824,9 +812,9 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	
 
 	// DCT & Zigzag & Quantization //
-	for(i=0; i<bHeight; i = i + 8)
+	for(int i=0; i<bHeight; i = i + 8)
 	{
-		for(j=0; j<bWidth; j = j + 8)
+		for(int j=0; j<bWidth; j = j + 8)
 		{
 			DCT(&Y[i*bWidth+j], bWidth, FALSE);
 			DCT(&Cb[i*bWidth+j], bWidth, TRUE);
@@ -844,9 +832,9 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	short *DC2 = new short[Num_X * Num_Y];
 	short *DC3 = new short[Num_X * Num_Y];
 
-	for(i=0; i<bHeight; i = i + 8)
+	for(int i=0; i<bHeight; i = i + 8)
 	{
-		for(j=0; j<bWidth; j = j + 8)
+		for(int j=0; j<bWidth; j = j + 8)
 		{
 			DC1[idx] = Y[i*bWidth+j];				
 			DC2[idx] = Cb[i*bWidth+j];
@@ -855,7 +843,7 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 		}
 	}	
 
-	for(i=Num_X * Num_Y - 1; i>0; i--)
+	for(int i=Num_X * Num_Y - 1; i>0; i--)
 	{		
 		DC1[i] = DC1[i] - DC1[i-1];
 		DC2[i] = DC2[i] - DC2[i-1];
@@ -863,9 +851,9 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	}
 
 	idx = 0;
-	for(i=0; i<bHeight; i = i + 8)
+	for(int i=0; i<bHeight; i = i + 8)
 	{
-		for(j=0; j<bWidth; j = j + 8)
+		for(int j=0; j<bWidth; j = j + 8)
 		{
 			 Y[i*bWidth+j] = DC1[idx];
 			 Cb[i*bWidth+j] = DC2[idx];
@@ -884,17 +872,17 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 
 	int Num, iTh[4] = {16, 17}, Th, key;
 
-	for(i=0; i<2; i++)
+	for(int i=0; i<2; i++)
 	{
 		Th = iTh[i];
 		Num = TbH[Th].Num;
 		TbH[Th].PT = new int[251];		
 
-		for(k=0; k<251; k++)
+		for(int k=0; k<251; k++)
 		{
 			key = -9999;
 			
-			for(j=0; j<Num; j++)
+			for(int j=0; j<Num; j++)
 			{
 				if(TbH[Th].HUFFVAL[j] == k)
 				{
@@ -926,14 +914,14 @@ void CJpeg::SaveJPG(LPCSTR FileName, int Width, int Height, BYTE *pp)
 	
 	// 임시 메모리 모두 해제 //
 
-	for(i=0; i<2; i++)
+	for(int i=0; i<2; i++)
 	{
 		Th = iTh[i];
 		delete [] TbH[Th].PT;
 	}	
 
-	for(i=0; i<bHeight; i++)
-		for(j=0; j<bWidth; j++)
+	for(int i=0; i<bHeight; i++)
+		for(int j=0; j<bWidth; j++)
 		{
 			idx1 = i*bWidth*3 + j*3;
 			m_pData[idx1] = (BYTE)Y[i*bWidth+j];
@@ -963,7 +951,6 @@ void CJpeg::PutSOF(HANDLE hFile, int Width, int Height)
 {
 	WORD Marker, SegSize, w;
 	BYTE c;
-	int i;
 
 	DWORD dwWritten;
 
@@ -985,7 +972,7 @@ void CJpeg::PutSOF(HANDLE hFile, int Width, int Height)
 
 	c = 3; 
 	WriteFile(hFile,(LPSTR)&c,1,&dwWritten,NULL);
-	for(i=1; i<=3; i++)
+	for(int i=1; i<=3; i++)
 	{
 		c = (BYTE)i; // Component Identifier
 		WriteFile(hFile,(LPSTR)&c,1,&dwWritten,NULL);
@@ -1006,7 +993,6 @@ void CJpeg::PutSOS(HANDLE hFile)
 {
 	WORD Marker, SegSize;
 	BYTE c;
-	int i;
 	DWORD dwWritten;
 
 	Marker = (0xda << 8) | 0xff;
@@ -1020,7 +1006,7 @@ void CJpeg::PutSOS(HANDLE hFile)
 	
 	WriteFile(hFile,(LPSTR)&c,1,&dwWritten,NULL);
 
-	for(i=1; i<=3; i++)
+	for(int i=1; i<=3; i++)
 	{
 		c = (BYTE)i; // Scan Component Selector		
 		WriteFile(hFile,(LPSTR)&c,1,&dwWritten,NULL);
@@ -1116,8 +1102,6 @@ void CJpeg::DCT(short * pos, int bWidth, BOOL Flag)
 					99, 99, 99, 99, 99, 99, 99, 99	};
 
 
-	int i, j;
-	int x, y, u, v;	
 	float Cu, Cv;
 	float Sum;
 	float dct_coeff[8][8] =
@@ -1132,14 +1116,14 @@ void CJpeg::DCT(short * pos, int bWidth, BOOL Flag)
 		+0.1951f, -0.5556f, +0.8315f, -0.9808f, +0.9808f, -0.8315f, +0.5556f, -0.1951f
 	};
 
-	for(v=0; v<8; v++)
+	for(int v=0; v<8; v++)
 	{
-		for(u=0; u<8; u++)
+		for(int u=0; u<8; u++)
 		{
 			Sum = 0;
 
-			for(y=0; y<8; y++)
-				for(x=0; x<8; x++)
+			for(int y=0; y<8; y++)
+				for(int x=0; x<8; x++)
 					Sum = Sum + pos[(int)(y*bWidth+x)] * dct_coeff[u][x] * dct_coeff[v][y];
 			
 			Cu = 1.; if(u == 0) Cu = 0.7071f;
@@ -1151,16 +1135,16 @@ void CJpeg::DCT(short * pos, int bWidth, BOOL Flag)
 	Zigzag2();	
 
 	if(Flag) // TRUE : Chrominance, FALSE : Luminance
-		for(i=0; i<64; i++)
+		for(int i=0; i<64; i++)
 			ZZ[i] = ZZ[i] / Qtb1[i];
 	else
-		for(i=0; i<64; i++)
+		for(int i=0; i<64; i++)
 			ZZ[i] = ZZ[i] / Qtb0[i];
 			
 
 
-	for(i=0; i<8; i++)
-		for(j=0; j<8; j++)
+	for(int i=0; i<8; i++)
+		for(int j=0; j<8; j++)
 			pos[i*bWidth+j] = ZZ[i*8+j];
 	
 }
@@ -1179,11 +1163,10 @@ void CJpeg::Zigzag2()
 	
 	short Temp[64];
 	memcpy(Temp, ZZ, 64 * sizeof(short));
-	int i, j, idx;
-	for(i=0; i<8; i++)
-		for(j=0; j<8; j++)
+	for(int i=0; i<8; i++)
+		for(int j=0; j<8; j++)
 		{
-			idx = (i<<3)+j;
+			int idx = (i<<3)+j;
 			ZZ[Index[idx]] = Temp[idx];
 		}
 
@@ -1266,11 +1249,9 @@ BYTE CJpeg::GetCategory(short V)
 
 void CJpeg::hEncode(int bWidth, int bHeight)
 {
-	int i, j;
-
-	for(i=0; i<bHeight; i = i + 8)
+	for(int i=0; i<bHeight; i = i + 8)
 	{
-		for(j=0; j<bWidth; j = j + 8)
+		for(int j=0; j<bWidth; j = j + 8)
 		{
 			EncodeDU(&Y[i*bWidth+j], FALSE, bWidth);
 			EncodeDU(&Cb[i*bWidth+j], TRUE, bWidth);
@@ -1288,7 +1269,6 @@ void CJpeg::EncodeDU(short * pos, BOOL Flag, int bWidth)
 	short XX[64], DIFF;	
 	BYTE ThDC, ThAC;
 	int idx = 0;	
-	int i, j;
 	
 	ThDC = 0; ThAC = 16;
 	if(Flag)
@@ -1296,9 +1276,9 @@ void CJpeg::EncodeDU(short * pos, BOOL Flag, int bWidth)
 		ThDC = 1; ThAC = 17;
 	}	
 
-	for(i=0; i<8; i++)
+	for(int i=0; i<8; i++)
 	{
-		for(j=0; j<8; j++)
+		for(int j=0; j<8; j++)
 		{
 			XX[idx] = pos[i*bWidth+j];
 			idx++;
@@ -1366,12 +1346,9 @@ void CJpeg::EncodeDU(short * pos, BOOL Flag, int bWidth)
 
 void CJpeg::ChargeCode(WORD Code, int Size)
 {
-	int i;
-	BYTE Bit;	
-
-	for(i=0; i<Size; i++)
+	for(int i=0; i<Size; i++)
 	{
-		Bit = (Code >> (Size - 1 - i)) & 0x01;
+		BYTE Bit = (Code >> (Size - 1 - i)) & 0x01;
 		ShotBit(Bit);		
 	}
 }

--- a/src/engine/N3Base/N3AlphaPrimitiveManager.cpp
+++ b/src/engine/N3Base/N3AlphaPrimitiveManager.cpp
@@ -63,7 +63,7 @@ void CN3AlphaPrimitiveManager::Render()
 	static __Material mtl; mtl.Init();
 	CN3Base::s_lpD3DDev->SetMaterial(&mtl);
 
-	for(i = 0; i < m_nToDrawCount; i++)
+	for (int i = 0; i < m_nToDrawCount; i++)
 	{
 
 		if(pBuffs[i]->nRenderFlags & RF_NOTUSEFOG) CN3Base::s_lpD3DDev->SetRenderState(D3DRS_FOGENABLE, FALSE);
@@ -270,7 +270,7 @@ void CN3AlphaPrimitiveManager::Render()
 	static __Material mtl; mtl.Init();
 	CN3Base::s_lpD3DDev->SetMaterial(&mtl);
 
-	for(i = 0; i < m_nToDrawCount; i++)
+	for(int i = 0; i < m_nToDrawCount; i++)
 	{
 		if(pBuffs[i]->nRenderFlags & RF_NOTUSEFOG)
 		{

--- a/src/engine/N3Base/N3Board.cpp
+++ b/src/engine/N3Base/N3Board.cpp
@@ -169,7 +169,7 @@ void CN3Board::LoadFromText(const std::string& szFName)
 	FILE* stream = fopen(szFName.c_str(), "r");
 	__ASSERT(stream, "지정한 파일을 찾을 수 없습니다.");
 	
-	int result, i, iCount;
+	int result, iCount;
 	char szBoardType[64]="";	__Vector3 vPos;	float fWidth, fHeight;
 	result = fscanf(stream, "Position = %f %f %f\n", &(vPos.x), &(vPos.y), &(vPos.z));	__ASSERT(result != EOF, "잘못된 Machine 세팅 파일");
 	result = fscanf(stream, "Size = %f %f\n", &fWidth, &fHeight);	__ASSERT(result != EOF, "잘못된 Machine 세팅 파일");
@@ -187,7 +187,7 @@ void CN3Board::LoadFromText(const std::string& szFName)
 	{
 		char szTexFName[_MAX_PATH];
 		TexAlloc(iCount);
-		for (i=0; i<iCount; ++i)
+		for (int i=0; i<iCount; ++i)
 		{
 			result = fscanf(stream, "Texture Name = %s\n", &szTexFName);		__ASSERT(result != EOF, "잘못된 Machine 세팅 파일");
 			TexSet(i, szTexFName);

--- a/src/engine/N3Base/N3Chr.cpp
+++ b/src/engine/N3Base/N3Chr.cpp
@@ -1052,10 +1052,10 @@ CN3Chr::~CN3Chr()
 	m_Parts.clear();
 
 	iPC = m_Plugs.size();
-	for(i = 0; i < iPC; i++) delete m_Plugs[i];
+	for(int i = 0; i < iPC; i++) delete m_Plugs[i];
 	m_Plugs.clear();
 
-	for(i = 0; i < m_vTraces.size(); i++) delete m_vTraces[i];
+	for(int i = 0; i < m_vTraces.size(); i++) delete m_vTraces[i];
 	m_vTraces.clear();
 
 	// Animation Control
@@ -1082,10 +1082,10 @@ void CN3Chr::Release()
 	m_Parts.clear();
 
 	iPC = m_Plugs.size();
-	for(i = 0; i < iPC; i++) delete m_Plugs[i];
+	for(int i = 0; i < iPC; i++) delete m_Plugs[i];
 	m_Plugs.clear();
 
-	for(i = 0; i < m_vTraces.size(); i++) delete m_vTraces[i];
+	for(int i = 0; i < m_vTraces.size(); i++) delete m_vTraces[i];
 	m_vTraces.clear();
 
 //	s_MngSkin.Delete(m_pSkinCollision);
@@ -1094,7 +1094,7 @@ void CN3Chr::Release()
 	// Animation Control
 	s_MngAniCtrl.Delete(&m_pAniCtrlRef);
 
-	for(i = 0; i < MAX_CHR_ANI_PART; i++)
+	for(int i = 0; i < MAX_CHR_ANI_PART; i++)
 	{
 		m_nJointPartStarts[i] = -1; // 조인트의 일부분이 따로 에니메이션 되야 한다면.. 조인트 인덱스 시작 번호
 		m_nJointPartEnds[i] = -1; // 조인트의 일부분이 따로 에니메이션 되야 한다면.. 조인트 인덱스 끝 번호
@@ -1147,7 +1147,7 @@ bool CN3Chr::Load(HANDLE hFile)
 	m_Plugs.clear();
 	ReadFile(hFile, &iPC, 4, &dwRWC, NULL);
 	this->PlugAlloc(iPC);
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		nL = 0;
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
@@ -1295,7 +1295,7 @@ bool CN3Chr::Save(HANDLE hFile)
 	
 	iPC = m_Plugs.size();
 	WriteFile(hFile, &iPC, 4, &dwRWC, NULL);
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		nL = m_Plugs[i]->FileName().size();
 		if(nL <= 0)
@@ -1394,7 +1394,7 @@ void CN3Chr::Tick(float fFrm)
 	else
 	{
 		int iJC = m_JointRefs.size();
-		for(i = 0; i < iJC; i++) // 걍 단순히 조인트만 Tick 해주고 나간다..
+		for(int i = 0; i < iJC; i++) // 걍 단순히 조인트만 Tick 해주고 나간다..
 		{
 			m_JointRefs[i]->TickAnimationKey(fFrm);
 			m_JointRefs[i]->ReCalcMatrix();
@@ -1664,7 +1664,7 @@ void CN3Chr::RemakePlugTracePolygons()
 
 	int iPC = m_Plugs.size();
 	m_vTraces.assign(iPC, NULL);
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		int iTS = m_Plugs[i]->m_nTraceStep;
 		if(iTS <= 0) continue;
@@ -1721,7 +1721,7 @@ void CN3Chr::Render()
 	// Plug - 붙이는 부분 Rendering
 	CN3CPlug* pPlug = NULL;
 	iPC = m_Plugs.size();
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		pPlug = m_Plugs[i];
 		
@@ -1782,9 +1782,6 @@ void CN3Chr::BuildMesh()
 	__ASSERT(m_pRootJointRef, "Joint pointer is NULL!");
 
 	float fWeight = 0;
-	int nJIndex = 0, nAffect = 0;
-
-	int i = 0, j = 0, k = 0, nVC = 0;
 	CN3IMesh* pIMesh = NULL;
 	CN3Skin* pSkin = NULL;
 
@@ -1792,7 +1789,7 @@ void CN3Chr::BuildMesh()
 	__Matrix44* pMtxJIs = &(m_MtxInverses[0]);
 
 	int iPC = m_Parts.size();
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		pSkin = m_Parts[i]->Skin(m_nLOD);
 		if(NULL == pSkin) continue;
@@ -1801,27 +1798,27 @@ void CN3Chr::BuildMesh()
 		__VertexSkinned* pVSrc = pSkin->SkinVertices();
 		if(NULL == pVDest || NULL == pVSrc) continue;
 
-		nVC = pSkin->VertexCount();
+		int nVC = pSkin->VertexCount();
 		__Vector3 vFinal;
 		int nAffect = 0;
 		float* pfWeights = NULL;
-		for(j = 0; j < nVC; j++) // j < m_nBoneVertices 와 같다..
+		for(int j = 0; j < nVC; j++) // j < m_nBoneVertices 와 같다..
 		{
 
 			nAffect = pVSrc[j].nAffect;
 			if(1 == nAffect)
 			{
 				// 단일 뼈대...
-				nJIndex = pVSrc[j].pnJoints[0];
+				int nJIndex = pVSrc[j].pnJoints[0];
 				pVDest[j] = (pVSrc[j].vOrigin * pMtxJIs[nJIndex]) * pMtxJs[nJIndex];
 			}
 			else if(nAffect > 1) 
 			{
 				vFinal.Zero();
 				pfWeights = pVSrc[j].pfWeights;
-				for(k = 0; k < nAffect; k++)
+				for(int k = 0; k < nAffect; k++)
 				{
-					nJIndex = pVSrc[j].pnJoints[k];
+					int nJIndex = pVSrc[j].pnJoints[k];
 					vFinal += ((pVSrc[j].vOrigin * pMtxJIs[nJIndex]) * pMtxJs[nJIndex]) * pfWeights[k];
 				}
 				pVDest[j] = vFinal;
@@ -1836,7 +1833,7 @@ void CN3Chr::BuildMesh()
 		__Vector3* pVDest = m_pMeshCollision->Vertices();
 		__VertexSkinned* pVSrc = m_pSkinCollision->Vertices();
 
-		nVC = m_pMeshCollision->VertexCount();
+		int nVC = m_pMeshCollision->VertexCount();
 		int nSVC = m_pSkinCollision->VertexCount();
 		if(nSVC != nVC)
 		{
@@ -1846,7 +1843,7 @@ void CN3Chr::BuildMesh()
 		{
 			int nAffect = 0;
 			float* pfWeights = NULL;
-			for(j = 0; j < nVC; j++) // j < m_nBoneVertices 와 같다..
+			for(int j = 0; j < nVC; j++) // j < m_nBoneVertices 와 같다..
 			{
 				nAffect = pVSrc[j].nAffect;
 				if(1 == nAffect)
@@ -1859,7 +1856,7 @@ void CN3Chr::BuildMesh()
 				{
 					pVDest[j].Zero();
 					pfWeights = pVSrc[j].pfWeights;
-					for(k = 0; k < nAffect; k++)
+					for(int k = 0; k < nAffect; k++)
 					{
 						if(pfWeights[k] <= 0) continue;
 
@@ -1881,9 +1878,6 @@ void CN3Chr::BuildMesh(int nLOD)
 	__ASSERT(m_pRootJointRef, "Joint pointer is NULL!");
 
 	float fWeight = 0;
-	int nJIndex = 0, nAffect = 0;
-
-	int i = 0, j = 0, k = 0, nVC = 0;
 	CN3IMesh* pIMesh = NULL;
 	CN3Skin* pSkin = NULL;
 
@@ -1891,7 +1885,7 @@ void CN3Chr::BuildMesh(int nLOD)
 	__Matrix44* pMtxJIs = &(m_MtxInverses[0]);
 
 	int iPC = m_Parts.size();
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		pSkin = m_Parts[i]->Skin(nLOD);
 		if(NULL == pSkin) continue;
@@ -1900,27 +1894,27 @@ void CN3Chr::BuildMesh(int nLOD)
 		__VertexSkinned* pVSrc = pSkin->SkinVertices();
 		if(NULL == pVDest || NULL == pVSrc) continue;
 
-		nVC = pSkin->VertexCount();
+		int nVC = pSkin->VertexCount();
 		__Vector3 vFinal;
 		int nAffect = 0;
 		float* pfWeights = NULL;
-		for(j = 0; j < nVC; j++) // j < m_nBoneVertices 와 같다..
+		for(int j = 0; j < nVC; j++) // j < m_nBoneVertices 와 같다..
 		{
 
 			nAffect = pVSrc[j].nAffect;
 			if(1 == nAffect)
 			{
 				// 단일 뼈대...
-				nJIndex = pVSrc[j].pnJoints[0];
+				int nJIndex = pVSrc[j].pnJoints[0];
 				pVDest[j] = (pVSrc[j].vOrigin * pMtxJIs[nJIndex]) * pMtxJs[nJIndex];
 			}
 			else if(nAffect > 1) 
 			{
 				vFinal.Zero();
 				pfWeights = pVSrc[j].pfWeights;
-				for(k = 0; k < nAffect; k++)
+				for(int k = 0; k < nAffect; k++)
 				{
-					nJIndex = pVSrc[j].pnJoints[k];
+					int nJIndex = pVSrc[j].pnJoints[k];
 					vFinal += ((pVSrc[j].vOrigin * pMtxJIs[nJIndex]) * pMtxJs[nJIndex]) * pfWeights[k];
 				}
 				pVDest[j] = vFinal;
@@ -1984,7 +1978,7 @@ void CN3Chr::PartAlloc(int iCount)
 	if(iCount > 0) 
 	{
 		m_Parts.assign(iCount, NULL);
-		for(i = 0; i < iCount; i++) m_Parts[i] = new CN3CPart();
+		for(int i = 0; i < iCount; i++) m_Parts[i] = new CN3CPart();
 	}
 }
 
@@ -2043,7 +2037,7 @@ void CN3Chr::PlugAlloc(int iCount)
 	if(iCount > 0) 
 	{
 		m_Plugs.assign(iCount, NULL);
-		for(i = 0; i < iCount; i++) m_Plugs[i] = new CN3CPlug();
+		for(int i = 0; i < iCount; i++) m_Plugs[i] = new CN3CPlug();
 	}
 }
 

--- a/src/engine/N3Base/N3Cloak.cpp
+++ b/src/engine/N3Base/N3Cloak.cpp
@@ -159,7 +159,7 @@ void CN3Cloak::Render(__Matrix44 &mtx)
 			s_lpD3DDev->DrawPrimitiveUP(D3DPT_LINELIST, 1, Vtx, sizeof(__VertexXyzColor));
 		}
 	}
-	for ( i = 0 ; i< m_nGridH-1;i++)
+	for (int i = 0 ; i< m_nGridH-1;i++)
 	{
 		for (int j=0;j<m_nGridW;j++)
 		{
@@ -183,17 +183,14 @@ void CN3Cloak::Render(__Matrix44 &mtx)
 #define SPRING_COEFFICIENT		0.3f
 void CN3Cloak::UpdateLocalForce()
 {
-	float length;
-
-	int i, j, index, idx;
 	D3DXVECTOR3 up, down, left, right;
 	const float nSub = 0.2f;
 
-	for ( i = 0; i < m_nGridH; i ++ )
+	for (int i = 0; i < m_nGridH; i++)
 	{
-		for ( j = 0; j < m_nGridW; j ++ )
+		for (int j = 0; j < m_nGridW; j++)
 		{
-			index = i*m_nGridW + j;			
+			int index = i*m_nGridW + j;			
 			
 			up.x = down.x = left.x = right.x = 0; 
 			up.y = down.y = left.y = right.y = 0; 
@@ -201,12 +198,12 @@ void CN3Cloak::UpdateLocalForce()
 			
 			if ( j-1 >= 0 )
 			{
-				idx = i*m_nGridW + (j-1);
+				int idx = i*m_nGridW + (j-1);
 				up.x = m_pParticle[idx].x - m_pParticle[index].x; 
 				up.y = m_pParticle[idx].y - m_pParticle[index].y; 
 				up.z = m_pParticle[idx].z - m_pParticle[index].z;
 				
-				length = sqrt(up.x * up.x + up.y * up.y + up.z * up.z);
+				int length = sqrt(up.x * up.x + up.y * up.y + up.z * up.z);
 
 				if (length > SPRING_TOLERANCE)
 				{
@@ -219,12 +216,12 @@ void CN3Cloak::UpdateLocalForce()
 			}
 			if ( j+1 < m_nGridW)
 			{
-				idx = i * m_nGridW + j+1;
+				int idx = i * m_nGridW + j+1;
 				down.x = m_pParticle[idx].x - m_pParticle[index].x; 
 				down.y = m_pParticle[idx].y - m_pParticle[index].y; 
 				down.z = m_pParticle[idx].z - m_pParticle[index].z; 
 
-				length = sqrt(down.x * down.x + down.y * down.y + down.z * down.z);
+				int length = sqrt(down.x * down.x + down.y * down.y + down.z * down.z);
 				if (length > SPRING_TOLERANCE)
 				{				
 					length = 1.0f-nSub/length;
@@ -235,12 +232,12 @@ void CN3Cloak::UpdateLocalForce()
 			}
 			if ( i-1 >= 0 )
 			{
-				idx = (i-1) * m_nGridW + j;
+				int idx = (i-1) * m_nGridW + j;
 				left.x = m_pParticle[idx].x - m_pParticle[index].x; 
 				left.y = m_pParticle[idx].y - m_pParticle[index].y; 
 				left.z = m_pParticle[idx].z - m_pParticle[index].z; 
 
-				length = sqrt(left.x * left.x + left.y * left.y + left.z * left.z);
+				int length = sqrt(left.x * left.x + left.y * left.y + left.z * left.z);
 				if (length > SPRING_TOLERANCE)
 				{
 					length = 1.0f-nSub/length;					
@@ -251,12 +248,12 @@ void CN3Cloak::UpdateLocalForce()
 			}
 			if ( i+1 < m_nGridH )
 			{
-				idx = (i+1) * m_nGridW + j;
+				int idx = (i+1) * m_nGridW + j;
 				right.x = m_pParticle[idx].x - m_pParticle[index].x; 
 				right.y = m_pParticle[idx].y - m_pParticle[index].y; 
 				right.z = m_pParticle[idx].z - m_pParticle[index].z; 
 
-				length = sqrt(right.x * right.x + right.y * right.y + right.z * right.z);
+				int length = sqrt(right.x * right.x + right.y * right.y + right.z * right.z);
 				if (length > SPRING_TOLERANCE)
 				{
 					length = 1.0f-nSub/length;
@@ -381,10 +378,9 @@ void CN3Cloak::SetLOD(int nLevel)
 	
 	m_pParticle = new __Particle[m_nGridW*m_nGridH];
 	__Particle *pParticle = m_pParticle;
-	int i,j;
-	for (i=0;i<m_nGridH;i++)
+	for (int i=0;i<m_nGridH;i++)
 	{
-		for (j=0;j<m_nGridW;j++)
+		for (int j=0;j<m_nGridW;j++)
 		{
 			pParticle->Set(0.5f, 2.0f-j*.2f, 2.0f-i*.2f, 0.0f, 0.0f, 0.0f, 0.0f);
 			pParticle++;

--- a/src/engine/N3Base/N3Cloud.cpp
+++ b/src/engine/N3Base/N3Cloud.cpp
@@ -33,8 +33,7 @@ CN3Cloud::CN3Cloud()
 
 CN3Cloud::~CN3Cloud()
 {
-	int i;
-	for (i=0; i<NUM_CLOUD; ++i)
+	for (int i=0; i<NUM_CLOUD; ++i)
 	{
 		s_MngTex.Delete(&m_pTextures[i]);
 	}
@@ -43,8 +42,7 @@ CN3Cloud::~CN3Cloud()
 void CN3Cloud::Release()
 {
 	CN3Base::Release();
-	int i;
-	for (i=0; i<NUM_CLOUD; ++i)
+	for (int i=0; i<NUM_CLOUD; ++i)
 	{
 		if (m_pTextures[i])
 		{
@@ -65,7 +63,6 @@ void CN3Cloud::Release()
 }
 void CN3Cloud::Tick()
 {
-	int i;
 	static float fCloudLayer = 0.0f;
 	fCloudLayer += s_fSecPerFrm;
 
@@ -81,7 +78,7 @@ void CN3Cloud::Tick()
 		float du2 = 0.015*fCloudLayer;
 		float dv2 = 0.025*fCloudLayer;
 
-		for (i=0; i<NUM_CLOUD_VERTEX; ++i)
+		for (int i=0; i<NUM_CLOUD_VERTEX; ++i)
 		{
 			m_pVertices[i].tu += du;
 			m_pVertices[i].tv += dv;
@@ -93,11 +90,11 @@ void CN3Cloud::Tick()
 
 		if (m_pVertices[0].tu > 10.0f)
 		{
-			for (i=0; i<NUM_CLOUD_VERTEX; ++i)	m_pVertices[i].tu -= 10.0f;
+			for (int i=0; i<NUM_CLOUD_VERTEX; ++i)	m_pVertices[i].tu -= 10.0f;
 		}
 		if (m_pVertices[0].tv > 10.0f)
 		{
-			for (i=0; i<NUM_CLOUD_VERTEX; ++i)	m_pVertices[i].tv -= 10.0f;
+			for (int i=0; i<NUM_CLOUD_VERTEX; ++i)	m_pVertices[i].tv -= 10.0f;
 		}
 	}
 
@@ -130,7 +127,7 @@ void CN3Cloud::Tick()
 				m_Alpha.ChangeColor(0x00ffffff, m_fCloudTexTime);
 
 				// uv 좌표도 바꾸기
-				for (i=0; i<NUM_CLOUD_VERTEX; ++i)
+				for (int i=0; i<NUM_CLOUD_VERTEX; ++i)
 				{
 					float fTempUV = m_pVertices[i].tu;
 					m_pVertices[i].tu = m_pVertices[i].tu2;
@@ -173,9 +170,8 @@ void CN3Cloud::Render()
 	D3DCOLOR color2 = m_Color2.GetCurColor();
 	__ASSERT(CLOUD_NONE != m_eCloud1 && CLOUD_NONE != m_eCloud2, "no cloud texture type");
 	// render cloud 1
-	int i;
-	for (i=0; i<4; ++i) m_pVertices[i].color = color1&0x00ffffff;
-	for (i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color1;
+	for (int i=0; i<4; ++i) m_pVertices[i].color = color1&0x00ffffff;
+	for (int i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color1;
 	s_lpD3DDev->SetTexture(0, GetTex(m_eCloud1));
 	s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, 8, 10,
 						CloudIndex, D3DFMT_INDEX16, m_pVertices, sizeof(__VertexXyzColorT2));
@@ -186,14 +182,14 @@ void CN3Cloud::Render()
 		D3DCOLOR Alpha = m_Alpha.GetCurColor();
 		if (Alpha<color2) color2 = (Alpha&0xff000000) | (color2&0x00ffffff);	// 기존 색 변화의 alpha값이 구름 교체alpha값보다 큰 경우 구름 교체 alpha값으로 대체
 		// render cloud 2
-		for (i=0; i<4; ++i) m_pVertices[i].color = color2&0x00ffffff;
-		for (i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color2;
+		for (int i=0; i<4; ++i) m_pVertices[i].color = color2&0x00ffffff;
+		for (int i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color2;
 		s_lpD3DDev->SetTexture(0, GetTex(m_eCloud2));
 		s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, 8, 10,
 							CloudIndex, D3DFMT_INDEX16, m_pVertices, sizeof(__VertexXyzColorT2));
 		// render cloud 3
 		D3DCOLOR color3 = ((0xff-(color2>>24))<<24) | (color2&0x00ffffff);	// color2의 alpha값을 0xff에서 뺀 값으로 바꿈
-		for (i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color3;			
+		for (int i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color3;			
 		s_lpD3DDev->SetTexture(0, GetTex(m_eCloud3));
 		s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, 8, 10,
 							CloudIndex, D3DFMT_INDEX16, m_pVertices, sizeof(__VertexXyzColorT2));
@@ -201,8 +197,8 @@ void CN3Cloud::Render()
 	else
 	{
 		// render cloud 2
-		for (i=0; i<4; ++i) m_pVertices[i].color = color2&0x00ffffff;
-		for (i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color2;
+		for (int i=0; i<4; ++i) m_pVertices[i].color = color2&0x00ffffff;
+		for (int i=4; i<NUM_CLOUD_VERTEX; ++i) m_pVertices[i].color = color2;
 		s_lpD3DDev->SetTexture(0, GetTex(m_eCloud2));
 		s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, 8, 10,
 							CloudIndex, D3DFMT_INDEX16, m_pVertices, sizeof(__VertexXyzColorT2));

--- a/src/engine/N3Base/N3Eng.cpp
+++ b/src/engine/N3Base/N3Eng.cpp
@@ -171,7 +171,7 @@ bool CN3Eng::Init(BOOL bWindowed, HWND hWnd, DWORD dwWidth, DWORD dwHeight, DWOR
 //#endif // end of _N3TOOL
 
 	int nMC = m_DeviceInfo.nModeCount;
-	for(i = 0; i < nMC; i++)
+	for(int i = 0; i < nMC; i++)
 	{
 //		if(	m_DeviceInfo.pModes[i].Width == dwWidth && 
 //			m_DeviceInfo.pModes[i].Height == dwHeight && 
@@ -242,7 +242,7 @@ bool CN3Eng::Init(BOOL bWindowed, HWND hWnd, DWORD dwWidth, DWORD dwHeight, DWOR
 	if(s_DevCaps.TextureCaps & D3DPTEXTURECAPS_POW2) s_dwTextureCaps |= TEX_CAPS_POW2;
 
 	// 기본 라이트 정보 지정..
-	for(i = 0; i < 8; i++)
+	for(int i = 0; i < 8; i++)
 	{
 		CN3Light::__Light Lgt;
 		_D3DCOLORVALUE LgtColor = { 1.0f, 1.0f, 1.0f, 1.0f };

--- a/src/engine/N3Base/N3EngTool.cpp
+++ b/src/engine/N3Base/N3EngTool.cpp
@@ -14,8 +14,7 @@
 CN3EngTool::CN3EngTool()
 {
 	// 淑切識 持失..
-	int i = 0;
-	for(i = -10; i < 10; i++)
+	for(int i = -10; i < 10; i++)
 	{
 		m_VAxis[ 0 + i + 10].Set(i * 500.0f, 0, 0, 0xffff0000); // X
 		m_VAxis[20 + i + 10].Set(0, i * 500.0f, 0, 0xff00ff00); // Y

--- a/src/engine/N3Base/N3FXPMeshInstance.cpp
+++ b/src/engine/N3Base/N3FXPMeshInstance.cpp
@@ -270,8 +270,7 @@ void CN3FXPMeshInstance::Render()
 	{
 		int iPC = m_iNumIndices / 3;
 
-		int iLC = iPC / iPCToRender;
-		int i;
+		int i, iLC = iPC / iPCToRender;
 		for (i=0; i<iLC; ++i)
 		{
 			s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, m_iNumVertices, iPCToRender, m_pIndices + i*iPCToRender*3, D3DFMT_INDEX16, m_pColorVertices, sizeof(__VertexXyzColorT1));
@@ -298,8 +297,7 @@ void CN3FXPMeshInstance::RenderTwoUV()
 	{
 		int iPC = m_iNumIndices / 3;
 
-		int iLC = iPC / iPCToRender;
-		int i;
+		int i, iLC = iPC / iPCToRender;
 		for (i=0; i<iLC; ++i)
 		{
 			s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, m_iNumVertices, iPCToRender, m_pIndices + i*iPCToRender*3, D3DFMT_INDEX16, m_pFXPMesh->m_pVertices2, sizeof(__VertexT2));

--- a/src/engine/N3Base/N3FXPartBillBoard.cpp
+++ b/src/engine/N3Base/N3FXPartBillBoard.cpp
@@ -390,7 +390,7 @@ void CN3FXPartBillBoard::Render()
 				vUnit[i] *= mtxRotZ;
 			}
 
-			for(i=0;i<m_iNum;i++)
+			for(int i=0;i<m_iNum;i++)
 			{
 				int idx = i*4;
 				
@@ -488,7 +488,7 @@ void CN3FXPartBillBoard::Render()
 				vUnit[i] *= mtxRotZ;
 			}
 
-			for(i=0;i<m_iNum;i++)
+			for(int i=0;i<m_iNum;i++)
 			{
 				int idx = i*4;
 

--- a/src/engine/N3Base/N3FXPartParticles.cpp
+++ b/src/engine/N3Base/N3FXPartParticles.cpp
@@ -74,7 +74,7 @@ CN3FXPartParticles::CN3FXPartParticles()
 	m_fScaleVelX = m_fScaleVelY = 0.0f;
 
 #ifdef _N3TOOL
-	for(i=0;i<NUM_KEY_COLOR;i++)
+	for(int i=0;i<NUM_KEY_COLOR;i++)
 	{
 		m_bChangeColorKey[i] = false;
 		m_bChangeAlphaKey[i] = false;
@@ -87,10 +87,8 @@ CN3FXPartParticles::~CN3FXPartParticles()
 	CN3FXPartBase::~CN3FXPartBase();
 
 	std::list<CN3FXParticle*>::iterator it;
-
-	int i;
 	it = m_pVBList_Alive.begin();
-	for(i=0;i<m_pVBList_Alive.size();i++, it++)
+	for(int i=0;i<m_pVBList_Alive.size();i++, it++)
 	{
 		CN3FXParticle* pParticle = (*it);
 		if(pParticle) delete pParticle;		
@@ -98,7 +96,7 @@ CN3FXPartParticles::~CN3FXPartParticles()
 	m_pVBList_Alive.clear();
 
 	it = m_pVBList_Dead.begin();
-	for(i=0;i<m_pVBList_Dead.size();i++, it++)
+	for(int i=0;i<m_pVBList_Dead.size();i++, it++)
 	{
 		CN3FXParticle* pParticle = (*it);
 		if(pParticle) delete pParticle;
@@ -324,9 +322,8 @@ void CN3FXPartParticles::Init()
 	}
 
 	std::list<CN3FXParticle*>::iterator it;
-	int i;
 	it = m_pVBList_Alive.begin();
-	for(i=0;i<m_pVBList_Alive.size();i++, it++)
+	for(int i=0;i<m_pVBList_Alive.size();i++, it++)
 	{
 		m_pVBList_Dead.push_back((*it));
 	}
@@ -335,7 +332,7 @@ void CN3FXPartParticles::Init()
 	m_CurrCreateDelay = m_fCreateDelay;
 
 	it = m_pVBList_Dead.begin();
-	for(i=0;i<m_pVBList_Dead.size();i++, it++)
+	for(int i=0;i<m_pVBList_Dead.size();i++, it++)
 	{
 		CN3FXParticle* pParticle = (*it);
 
@@ -883,23 +880,21 @@ void CN3FXPartParticles::Render()
 void CN3FXPartParticles::InitVB()
 {
 	std::list<CN3FXParticle*>::iterator it;
-
-	int i;
 	it = m_pVBList_Alive.begin();
-	for(i=0;i<m_pVBList_Alive.size();i++, it++)
+	for(int i=0;i<m_pVBList_Alive.size();i++, it++)
 	{
 		delete (*it);		
 	}
 	m_pVBList_Alive.clear();
 
 	it = m_pVBList_Dead.begin();
-	for(i=0;i<m_pVBList_Dead.size();i++, it++)
+	for(int i=0;i<m_pVBList_Dead.size();i++, it++)
 	{
 		delete (*it);		
 	}
 	m_pVBList_Dead.clear();
 
-	for(i=0;i<m_iNumParticle;i++)
+	for(int i=0;i<m_iNumParticle;i++)
 	{
 		CN3FXParticle* pParticle = new CN3FXParticle;
 		pParticle->m_iID = i * NUM_VERTEX_PARTICLE;

--- a/src/engine/N3Base/N3FXParticle.cpp
+++ b/src/engine/N3Base/N3FXParticle.cpp
@@ -119,7 +119,7 @@ bool CN3FXParticle::Tick()
 		else m_dwColor = 0x00ffffff;
 	}
 
-	for(i=0;i<NUM_VERTEX_PARTICLE;i++) m_pVB[i].color = m_dwColor;
+	for(int i=0;i<NUM_VERTEX_PARTICLE;i++) m_pVB[i].color = m_dwColor;
 
 	m_vVelocity += m_vAccel * CN3Base::s_fSecPerFrm;
 	m_fRot += CN3Base::s_fSecPerFrm*m_pRefParent->m_fPtRotVelocity;

--- a/src/engine/N3Base/N3FXPlug.cpp
+++ b/src/engine/N3Base/N3FXPlug.cpp
@@ -151,8 +151,7 @@ CN3FXPlug::CN3FXPlug()
 
 CN3FXPlug::~CN3FXPlug()
 {
-	int i, nCount = m_FXPParts.size();
-	for (i=0; i<nCount; ++i) delete m_FXPParts[i];
+	for (int i=0; i<m_FXPParts.size(); ++i) delete m_FXPParts[i];
 	m_FXPParts.clear();
 }
 
@@ -160,8 +159,7 @@ void CN3FXPlug::Release()
 {
 	CN3BaseFileAccess::Release();
 
-	int i, nCount = m_FXPParts.size();
-	for (i=0; i<nCount; ++i) delete m_FXPParts[i];
+	for (int i=0; i<m_FXPParts.size(); ++i) delete m_FXPParts[i];
 	m_FXPParts.clear();
 }
 
@@ -170,11 +168,10 @@ bool CN3FXPlug::Load(HANDLE hFile)
 	if (false == CN3BaseFileAccess::Load(hFile)) return false;
 	__ASSERT(0 == m_FXPParts.size(), "must 0");
 	DWORD dwNum;
-	int i, nCount;
+	int nCount;
 	ReadFile(hFile, &nCount, sizeof(nCount), &dwNum, NULL);		// Part의 갯수
-
 	if (nCount > 0) m_FXPParts.assign(nCount, NULL);
-	for(i=0; i<nCount; ++i)
+	for(int i=0; i<nCount; ++i)
 	{
 		m_FXPParts[i] = new CN3FXPlugPart();
 		m_FXPParts[i]->Load(hFile);
@@ -185,20 +182,17 @@ bool CN3FXPlug::Load(HANDLE hFile)
 void CN3FXPlug::Tick(const CN3Chr* pChr)
 {
 	if (NULL == pChr) return;
-	int i, nCount = m_FXPParts.size();
-	for(i=0; i<nCount; ++i) m_FXPParts[i]->Tick(pChr);
+	for(int i=0; i<m_FXPParts.size(); ++i) m_FXPParts[i]->Tick(pChr);
 }
 
 void CN3FXPlug::Render()
 {
-	int i, nCount = m_FXPParts.size();
-	for(i=0; i<nCount; ++i) m_FXPParts[i]->Render();
+	for(int i=0; i<m_FXPParts.size(); ++i) m_FXPParts[i]->Render();
 }
 
 void CN3FXPlug::StopAll(bool bImmediately)
 {
-	int i, nCount = m_FXPParts.size();
-	for(i=0; i<nCount; ++i)
+	for(int i=0; i<m_FXPParts.size(); ++i)
 	{
 		m_FXPParts[i]->StopFXB(bImmediately);
 	}
@@ -206,8 +200,7 @@ void CN3FXPlug::StopAll(bool bImmediately)
 
 void CN3FXPlug::TriggerAll()
 {
-	int i, nCount = m_FXPParts.size();
-	for(i=0; i<nCount; ++i)
+	for(int i=0; i<m_FXPParts.size(); ++i)
 	{
 		m_FXPParts[i]->TriggerFXB();
 	}
@@ -221,17 +214,16 @@ bool CN3FXPlug::Save(HANDLE hFile)
 	RemoveFXPParts_HaveNoBundle();	// 번들 없는 파트들 지우기
 
 	DWORD dwNum;
-	int i, nCount = m_FXPParts.size();
+	int nCount = m_FXPParts.size();
 	WriteFile(hFile, &nCount, sizeof(nCount), &dwNum, NULL);		// Part의 갯수
-	for(i=0; i<nCount; ++i)	m_FXPParts[i]->Save(hFile);
+	for(int i=0; i<nCount; ++i)	m_FXPParts[i]->Save(hFile);
 
 	return true;
 }
 
 void CN3FXPlug::RemoveFXPParts_HaveNoBundle()	// 번들 없는 Part들 제거하기
 {
-	int i, nCount = m_FXPParts.size();
-	for(i=0; i<nCount; ++i)
+	for(int i=0; i<m_FXPParts.size(); ++i)
 	{
 		if (m_FXPParts[i] && NULL == m_FXPParts[i]->GetFXB())
 		{

--- a/src/engine/N3Base/N3GERain.cpp
+++ b/src/engine/N3Base/N3GERain.cpp
@@ -56,8 +56,6 @@ void CN3GERain::Tick()
 	}
 	if(iActiveCount <= 0) return;
 
-	int i;
-
 	__VertexXyzColor* pVertices;
 	HRESULT hr = m_pVB->Lock(0, 0, (VOID**)&pVertices, D3DLOCK_NOSYSLOCK);
 
@@ -69,7 +67,7 @@ void CN3GERain::Tick()
 	const float fHalfHeight = m_fHeight/2.0f;
 	const float fCurY = s_CameraData.vEye.y;
 
-	for (i=0; i<iActiveCount; ++i)
+	for (int i=0; i<iActiveCount; ++i)
 	{
 		// tail 위치 결정하기
 		__VertexXyzColor* pVTail = pVertices+i*2+0;
@@ -210,10 +208,9 @@ void CN3GERain::Create(float fDensity,
 
 	const DWORD dwColorA = 0x00bfbfbf,	// 꼬리
 				dwColorB = 0x80bfbfbf;	// 머리
-	int i;
 	__Vector3 vN = vVelocity; vN.Normalize();
 	__Vector3 vAdd = vN*fRainLength;
-	for (i=0; i<iRainCount; ++i)
+	for (int i=0; i<iRainCount; ++i)
 	{
 		pVertices[i*2+0].Set(	fWidth*(rand()%10000-5000)/10000.f,
 								fHeight*(rand()%10000-5000)/10000.f,

--- a/src/engine/N3Base/N3GESnow.cpp
+++ b/src/engine/N3Base/N3GESnow.cpp
@@ -58,7 +58,6 @@ void CN3GESnow::Tick()
 	}
 	if(iActiveCount <= 0) return;
 
-	int i;
 	__VertexXyzT1* pVertices;
 	HRESULT hr = m_pVB->Lock(0, 0, (VOID**)&pVertices, D3DLOCK_NOSYSLOCK);
 
@@ -72,7 +71,7 @@ void CN3GESnow::Tick()
 
 	static const float sqrt3 = sqrtf(3.0f);
 
-	for (i=0; i<iActiveCount; ++i)
+	for (int i=0; i<iActiveCount; ++i)
 	{
 		// 위치 결정하기
 		__VertexXyzT1* pV1 = pVertices+i*3+0;
@@ -228,8 +227,7 @@ void CN3GESnow::Create(float fDensity, float fWidth, float fHeight, float fSnowS
 	m_pSnowParticle = new __SnowParticle[iSnowCount];
 
 	const float sqrt3 = sqrtf(3.0f);
-	int i;
-	for (i=0; i<iSnowCount; ++i)
+	for (int i=0; i<iSnowCount; ++i)
 	{
 		m_pSnowParticle[i].vPos.Set(fWidth*(rand()%10000-5000)/10000.f,
 									fHeight*(rand()%10000-5000)/10000.f,

--- a/src/engine/N3Base/N3GlobalEffectMng.cpp
+++ b/src/engine/N3Base/N3GlobalEffectMng.cpp
@@ -43,9 +43,8 @@ void CN3GlobalEffectMng::Tick()
 	if (NewCellPos.x != m_CurCellPos.x || NewCellPos.y != m_CurCellPos.y)
 	{
 		m_CurCellPos = NewCellPos;
-		int i, j;
-		for(i=0; i<3; ++i)
-			for(j=0; j<3; ++j)
+		for(int i=0; i<3; ++i)
+			for(int j=0; j<3; ++j)
 				m_vPos[j*3+i].Set( (m_CurCellPos.x+i-0.5f)*m_fCellSize, 0, (m_CurCellPos.y+j-0.5f)*m_fCellSize);
 	}
 
@@ -64,10 +63,9 @@ void CN3GlobalEffectMng::Tick()
 
 void CN3GlobalEffectMng::Render()
 {
-	int i, j;
-	for (i=0; i<3; ++i)
+	for (int i=0; i<3; ++i)
 	{
-		for(j=0; j<3; ++j)
+		for(int j=0; j<3; ++j)
 		{
 			if (m_pGERain)
 			{

--- a/src/engine/N3Base/N3IME.cpp
+++ b/src/engine/N3Base/N3IME.cpp
@@ -422,7 +422,7 @@ BOOL CN3IME::ChangeCandidate(LONG CandList)
     dwPreferNumPerPage = (!lpCandList->dwPageSize ) ?
                          DEFAULT_CAND_NUM_PER_PAGE : lpCandList->dwPageSize;
 
-    for( i = 0; i < lpCandList->dwCount; i++ ) {
+    for( int i = 0; i < lpCandList->dwCount; i++ ) {
         lpStr = (LPSTR)lpCandList + lpCandList->dwOffset[i];
         max_width = (max_width < lstrlen(lpStr)) ? lstrlen(lpStr) : max_width;
     }

--- a/src/engine/N3Base/N3Joint.cpp
+++ b/src/engine/N3Base/N3Joint.cpp
@@ -503,7 +503,7 @@ void CN3Joint::KeyDelete(CN3Joint *pJoint, int nKS, int nKE)
 
 	// Child 를 다시 만들어 준다.
 	int nCC = pJoint->ChildCount();
-	for(i = 0; i < nCC; i++)
+	for(int i = 0; i < nCC; i++)
 	{
 		CN3Joint* pChild = pJoint->Child(i);
 		pChild->KeyDelete(pChild, nKS, nKE); // 하위 조인트를 복사..

--- a/src/engine/N3Base/N3Mesh.cpp
+++ b/src/engine/N3Base/N3Mesh.cpp
@@ -113,7 +113,8 @@ void CN3Mesh::MakeIndexed()
 	for(int i = 0; i < m_nVC; i++)
 	{
 		BOOL bAccord = FALSE;
-		for(int j = 0; j < nVCount; j++)
+		int j;
+		for(j = 0; j < nVCount; j++)
 		{
 			if(	m_pVertices[i].x == pVs[j].x && 
 				m_pVertices[i].y == pVs[j].y && 
@@ -143,7 +144,7 @@ void CN3Mesh::MakeIndexed()
 
 	this->Create(nVCount, m_nVC);
 	memcpy(m_pVertices, pVs, sizeof(__VertexT1)*nVCount);
-	for(i = 0 ; i < m_nIC; i++)
+	for(int i = 0 ; i < m_nIC; i++)
 		m_psnIndices[i] = nIs[i];
 
 	delete [] pVs; pVs = NULL;
@@ -206,43 +207,41 @@ void CN3Mesh::Create_Cube(__Vector3 &vMin, __Vector3 &vMax)
 	__Vector3 vN;
 	float fTUVs[6][2] = { 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1 };
 
-	int i = 0;
-
 	// z 축 음의 면
 	vN.Set(0,0,-1);
 	vPs[0].Set(vMin.x, vMax.y, vMin.z); vPs[1].Set(vMax.x, vMax.y, vMin.z); vPs[2].Set(vMax.x, vMin.y, vMin.z);
 	vPs[3] = vPs[0]; vPs[4] = vPs[2]; vPs[5].Set(vMin.x, vMin.y, vMin.z);
-	for(i = 0; i < 6; i++) m_pVertices[0+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
+	for(int i = 0; i < 6; i++) m_pVertices[0+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
 
 	// x 축 양의 면
 	vN.Set(1, 0, 0);
 	vPs[0].Set(vMax.x, vMax.y, vMin.z); vPs[1].Set(vMax.x, vMax.y, vMax.z); vPs[2].Set(vMax.x, vMin.y, vMax.z);
 	vPs[3] = vPs[0]; vPs[4] = vPs[2]; vPs[5].Set(vMax.x, vMin.y, vMin.z);
-	for(i = 0; i < 6; i++) m_pVertices[6+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
+	for(int i = 0; i < 6; i++) m_pVertices[6+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
 
 	// z 축 양의 면
 	vN.Set(0, 0, 1);
 	vPs[0].Set(vMax.x, vMax.y, vMax.z); vPs[1].Set(vMin.x, vMax.y, vMax.z); vPs[2].Set(vMin.x, vMin.y, vMax.z);
 	vPs[3] = vPs[0]; vPs[4] = vPs[2]; vPs[5].Set(vMax.x, vMin.y, vMax.z);
-	for(i = 0; i < 6; i++) m_pVertices[12+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
+	for(int i = 0; i < 6; i++) m_pVertices[12+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
 
 	// x 축 음의 면
 	vN.Set(-1, 0, 0);
 	vPs[0].Set(vMin.x, vMax.y, vMax.z); vPs[1].Set(vMin.x, vMax.y, vMin.z); vPs[2].Set(vMin.x, vMin.y, vMin.z);
 	vPs[3] = vPs[0]; vPs[4] = vPs[2]; vPs[5].Set(vMin.x, vMin.y, vMax.z);
-	for(i = 0; i < 6; i++) m_pVertices[18+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
+	for(int i = 0; i < 6; i++) m_pVertices[18+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
 
 	// y 축 양의 면
 	vN.Set(0, 1, 0);
 	vPs[0].Set(vMin.x, vMax.y, vMax.z); vPs[1].Set(vMax.x, vMax.y, vMax.z); vPs[2].Set(vMax.x, vMax.y, vMin.z);
 	vPs[3] = vPs[0]; vPs[4] = vPs[2]; vPs[5].Set(vMin.x, vMax.y, vMin.z);
-	for(i = 0; i < 6; i++) m_pVertices[24+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
+	for(int i = 0; i < 6; i++) m_pVertices[24+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
 
 	// y 축 음의 면
 	vN.Set(0, -1, 0);
 	vPs[0].Set(vMin.x, vMin.y, vMin.z); vPs[1].Set(vMax.x, vMin.y, vMin.z); vPs[2].Set(vMax.x, vMin.y, vMax.z);
 	vPs[3] = vPs[0]; vPs[4] = vPs[2]; vPs[5].Set(vMin.x, vMin.y, vMax.z);
-	for(i = 0; i < 6; i++) m_pVertices[30+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
+	for(int i = 0; i < 6; i++) m_pVertices[30+i].Set(vPs[i], vN, fTUVs[i][0], fTUVs[i][1]);
 
 	this->FindMinMax();
 }
@@ -280,7 +279,7 @@ void CN3Mesh::Create_Axis(float fLength)
 
 	// z 축
 	mtx.RotationY(D3DX_PI / -2.0f);
-	for(i = 0; i < 4; i++) 
+	for(int i = 0; i < 4; i++) 
 	{
 		m_pVertices[8+i].Set(m_pVertices[i] * mtx, m_pVertices[i].n * mtx, 0, 0);
 	}

--- a/src/engine/N3Base/N3PMeshCreate.cpp
+++ b/src/engine/N3Base/N3PMeshCreate.cpp
@@ -291,15 +291,14 @@ done_triangle_list:
 	memset(referred, 0, sizeof(referred));
 	__ASSERT(m_iNumVertices < MAX_VERTICES_PER_MATERIAL, "You must increase MAX_VERTICES_PER_MATERIAL");
 
-	int i;
-	for (i = 0; i < m_iNumIndices; i++)
+	for (int i = 0; i < m_iNumIndices; i++)
 	{
 		__ASSERT(m_pIndices[i] < m_iNumVertices, "indices array index overflow");
 		referred[m_pIndices[i]] = 1;
 	}
 
 	// If not, let's lose them.
-	for (i = 0; i < m_iNumVertices;)
+	for (int i = 0; i < m_iNumVertices;)
 	{
 		if (!referred[i])
 		{
@@ -539,8 +538,7 @@ bool CN3PMeshCreate::FindACollapse(float &val_so_far)
 
 #ifdef _SAME_VERTEXPOS
 	// 같은 점 찾기
-	int i;
-	for (i=0; i<m_iNumVertices; ++i)
+	for (int i=0; i<m_iNumVertices; ++i)
 	{
 		if (m_pVertices[be_index_b].x == m_pVertices[i].x &&
 			m_pVertices[be_index_b].y == m_pVertices[i].y &&
@@ -603,10 +601,8 @@ CN3PMesh *CN3PMeshCreate::CreateRendererMesh()
 	pPMesh->m_iNumCollapses = m_pCollapseUpTo - m_pCollapses;
 
 	// Copy the collapses in reverse order, so that the lowest detail collapses are first
-	int i;
-
 	float fTempValue = 0.0f;
-	for (i = 0; i < pPMesh->m_iNumCollapses; i++)
+	for (int i = 0; i < pPMesh->m_iNumCollapses; i++)
 	{
 		__PMCEdgeCollapse &src  = m_pCollapses[pPMesh->m_iNumCollapses - i - 1];
 		CN3PMesh::__EdgeCollapse &dest = pPMesh->m_pCollapses[i];
@@ -685,10 +681,8 @@ int CN3PMeshCreate::ReGenerate(CN3PMesh *pPMesh)
 	pPMesh->m_iNumCollapses = m_pCollapseUpTo - m_pCollapses;
 
 	// Copy the collapses in reverse order, so that the lowest detail collapses are first
-	int i;
-
 	float fTempValue = 0.0f;
-	for (i = 0; i < pPMesh->m_iNumCollapses; i++)
+	for (int i = 0; i < pPMesh->m_iNumCollapses; i++)
 	{
 		__PMCEdgeCollapse &src  = m_pCollapses[pPMesh->m_iNumCollapses - i - 1];
 		CN3PMesh::__EdgeCollapse &dest = pPMesh->m_pCollapses[i];
@@ -914,9 +908,7 @@ float CN3PMeshCreate::GetLossOfSamePosVertex(WORD pt_to, WORD pt_from)
 	float x = m_pVertices[pt_from].x;
 	float y = m_pVertices[pt_from].y;
 	float z = m_pVertices[pt_from].z;
-
-	int i;
-	for (i=0; i<m_iNumVertices; ++i)
+	for (int i=0; i<m_iNumVertices; ++i)
 	{
 		// from 과 같은 위치의 Vertex찾기
 		if (i != pt_to && i != pt_from &&

--- a/src/engine/N3Base/N3Pond.cpp
+++ b/src/engine/N3Base/N3Pond.cpp
@@ -119,7 +119,6 @@ bool CN3Pond::Load(HANDLE hFile)
 		ptmpPondMesh->m_iIC = iIC;		///
 		ptmpPondMesh->m_wpIndex = new WORD [iVC*6];		///
 
-		int j,k;
 		int iWidth = iWidthVertex,iHeight = iVC/iWidthVertex;
 		int x=0,y=iWidth;
 		WORD* indexPtr = ptmpPondMesh->m_wpIndex;	//	삼각형을 부를 위치 설정
@@ -129,9 +128,9 @@ bool CN3Pond::Load(HANDLE hFile)
 		float StX,EnX,StZ,EnZ;
 		StX = ptVtx[0].x,EnX = ptVtx[iWidth].x;
 		StZ = ptVtx[0].z,EnZ = ptVtx[iHeight].z;
-		for (j=0; j<iHeight; j++)
+		for (int j=0; j<iHeight; j++)
 		{
-			for (k=0; k<iWidth; k++)
+			for (int k=0; k<iWidth; k++)
 			{
 				//	삼각형을 부를 위치 설정
 				indexPtr[0] = x;
@@ -208,7 +207,7 @@ bool CN3Pond::Load(HANDLE hFile)
 	if(m_iPondMeshNum<=0) return false;
 
 	char szFileName[30];
-	for (i=0;i<MAX_POND_TEX;i++)
+	for (int i=0;i<MAX_POND_TEX;i++)
 	{
 		sprintf(szFileName, "misc\\river\\caust%02d.dxt", i);
 		m_pTexPond[i] = CN3Base::s_MngTex.Get(szFileName);

--- a/src/engine/N3Base/N3River.cpp
+++ b/src/engine/N3Base/N3River.cpp
@@ -76,7 +76,7 @@ bool CN3River::Load(HANDLE hFile)
 		pInfo->pDiff = new _RIVER_DIFF[pInfo->iVC];
 		float fAdd = 0.0f;
 		float fMul = 0.002f;
-		for (l=0;l<pInfo->iVC;l++)
+		for (int l=0;l<pInfo->iVC;l++)
 		{
 			pInfo->pDiff[l].fDiff = fAdd;
 			if (l%2==0)
@@ -93,14 +93,13 @@ bool CN3River::Load(HANDLE hFile)
 			}
 		}
 
-		int j,k;
 		__VertexRiver* ptVtx = pInfo->pVertices;
 		float StX,EnX,StZ,EnZ;
 		StX = ptVtx[0].x,EnX = ptVtx[4].x;
 		StZ = ptVtx[0].z,EnZ = ptVtx[pInfo->iVC/4].z;
-		for (j=0; j<pInfo->iVC/4; j++)
+		for (int j=0; j<pInfo->iVC/4; j++)
 		{
-			for (k=0; k<4; k++)
+			for (int k=0; k<4; k++)
 			{
 				if(StX>ptVtx->x) StX = ptVtx->x;
 				if(EnX<ptVtx->x) EnX = ptVtx->x;
@@ -121,7 +120,7 @@ bool CN3River::Load(HANDLE hFile)
 	}	
 
 	char szFileName[30];
-	for (i=0;i<MAX_RIVER_TEX;i++)
+	for (int i=0;i<MAX_RIVER_TEX;i++)
 	{
 		sprintf(szFileName, "misc\\river\\caust%02d.dxt", i);
 		m_pTexRiver[i] = s_MngTex.Get(szFileName);

--- a/src/engine/N3Base/N3River2.cpp
+++ b/src/engine/N3Base/N3River2.cpp
@@ -64,7 +64,7 @@ bool CN3River2::Load(HANDLE hFile)
 		pInfo->pDiff = new _RIVER_DIFF[pInfo->iVC];
 		float fAdd = 0.0f;
 		float fMul = 0.002f;
-		for (l=0;l<pInfo->iVC;l++)
+		for (int l=0;l<pInfo->iVC;l++)
 		{
 			pInfo->pDiff[l].fDiff = fAdd;
 			if (l%2==0)
@@ -81,14 +81,13 @@ bool CN3River2::Load(HANDLE hFile)
 			}
 		}
 
-		int j,k;
 		__VertexRiver* ptVtx = pInfo->pVertices;
 		float StX,EnX,StZ,EnZ;
 		StX = ptVtx[0].x,EnX = ptVtx[4].x;
 		StZ = ptVtx[0].z,EnZ = ptVtx[pInfo->iVC/4].z;
-		for (j=0; j<pInfo->iVC/4; j++)
+		for (int j=0; j<pInfo->iVC/4; j++)
 		{
-			for (k=0; k<4; k++)
+			for (int k=0; k<4; k++)
 			{
 				if(StX>ptVtx->x) StX = ptVtx->x;
 				if(EnX<ptVtx->x) EnX = ptVtx->x;
@@ -262,7 +261,7 @@ void CN3River2::Tick()
 		}
 	}
 	
-//	for (i=0;i<m_iRiverCount;i++)
+//	for (int i=0;i<m_iRiverCount;i++)
 //	{
 //		pInfo = m_pRiverInfo+i;
 //		for (int j=0;j<pInfo->iVC;j++)

--- a/src/engine/N3Base/N3RiverPatch.cpp
+++ b/src/engine/N3Base/N3RiverPatch.cpp
@@ -32,8 +32,7 @@ bool CN3RiverPatch::Load(HANDLE hFile)
 	DWORD dwNum;
 	ReadFile(hFile, &m_iRiverCount, sizeof(m_iRiverCount), &dwNum, NULL);
 	__River* pRivers = CreateRiver(m_iRiverCount);
-	int i;
-	for (i=0; i<m_iRiverCount; ++i)
+	for (int i=0; i<m_iRiverCount; ++i)
 	{
 		__River* pR = pRivers+i;
 		ReadFile(hFile, &(pR->iRiverID), sizeof(pR->iRiverID), &dwNum, NULL);
@@ -51,8 +50,7 @@ bool CN3RiverPatch::Save(HANDLE hFile)
 {
 	DWORD dwNum;
 	WriteFile(hFile, &m_iRiverCount, sizeof(m_iRiverCount), &dwNum, NULL);
-	int i;
-	for (i=0; i<m_iRiverCount; ++i)
+	for (int i=0; i<m_iRiverCount; ++i)
 	{
 		__River* pR = m_pRivers+i;
 		WriteFile(hFile, &(pR->iRiverID), sizeof(pR->iRiverID), &dwNum, NULL);
@@ -77,8 +75,7 @@ __River* CN3RiverPatch::CreateRiver(int iRiverCount)
 
 __River* CN3RiverPatch::GetRiverByID(int iRiverID)
 {
-	int i;
-	for (i=0; i<m_iRiverCount; ++i)
+	for (int i=0; i<m_iRiverCount; ++i)
 	{
 		if (m_pRivers[i].iRiverID == iRiverID)
 		{

--- a/src/engine/N3Base/N3Scene.cpp
+++ b/src/engine/N3Base/N3Scene.cpp
@@ -32,9 +32,8 @@ CN3Scene::CN3Scene()
 
 CN3Scene::~CN3Scene()
 {
-	int i = 0;
-	for(i = 0; i < MAX_SCENE_CAMERA; i++) { if(m_pCameras[i]) { delete m_pCameras[i]; m_pCameras[i] = NULL; } }
-	for(i = 0; i < MAX_SCENE_LIGHT; i++) { if(m_pLights[i]) { delete m_pLights[i]; m_pLights[i] = NULL; } }
+	for(int i = 0; i < MAX_SCENE_CAMERA; i++) { if(m_pCameras[i]) { delete m_pCameras[i]; m_pCameras[i] = NULL; } }
+	for(int i = 0; i < MAX_SCENE_LIGHT; i++) { if(m_pLights[i]) { delete m_pLights[i]; m_pLights[i] = NULL; } }
 	
 	this->ShapeRelease();
 	this->ChrRelease();
@@ -48,9 +47,8 @@ void CN3Scene::Release()
 	m_fFrmStart = 0.0f; // 전체 프레임.
 	m_fFrmEnd = 1000.0f; // 기본값 프레임.
 
-	int i = 0;
-	for(i = 0; i < MAX_SCENE_CAMERA; i++) { if(m_pCameras[i]) { delete m_pCameras[i]; m_pCameras[i] = NULL; } }
-	for(i = 0; i < MAX_SCENE_LIGHT; i++) { if(m_pLights[i]) { delete m_pLights[i]; m_pLights[i] = NULL; } }
+	for(int i = 0; i < MAX_SCENE_CAMERA; i++) { if(m_pCameras[i]) { delete m_pCameras[i]; m_pCameras[i] = NULL; } }
+	for(int i = 0; i < MAX_SCENE_LIGHT; i++) { if(m_pLights[i]) { delete m_pLights[i]; m_pLights[i] = NULL; } }
 	this->ShapeRelease();
 	this->ChrRelease();
 
@@ -69,12 +67,12 @@ bool CN3Scene::Load(HANDLE hFile)
 	ReadFile(hFile, &m_fFrmStart, 4, &dwRWC, NULL); // 전체 프레임.
 	ReadFile(hFile, &m_fFrmEnd, 4, &dwRWC, NULL); // 전체 프레임.
 
-	int i = 0, nL = 0;
+	int nL = 0;
 	char szName[512] = "";
 
 	int nCC = 0;
 	ReadFile(hFile, &nCC, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < nCC; i++)
+	for(int i = 0; i < nCC; i++)
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -94,7 +92,7 @@ bool CN3Scene::Load(HANDLE hFile)
 
 	int nLC = 0;
 	ReadFile(hFile, &nLC, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < nLC; i++) 
+	for(int i = 0; i < nLC; i++) 
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -114,7 +112,7 @@ bool CN3Scene::Load(HANDLE hFile)
 
 	int nSC = 0;
 	ReadFile(hFile, &nSC, 4, &dwRWC, NULL); // Shapes..
-	for(i = 0; i < nSC; i++)
+	for(int i = 0; i < nSC; i++)
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -134,7 +132,7 @@ bool CN3Scene::Load(HANDLE hFile)
 
 	int nChrC = 0;
 	ReadFile(hFile, &nChrC, 4, &dwRWC, NULL); // 캐릭터
-	for(i = 0; i < nChrC; i++)
+	for(int i = 0; i < nChrC; i++)
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -171,22 +169,20 @@ bool CN3Scene::Save(HANDLE hFile)
 	WriteFile(hFile, &m_fFrmCur, 4, &dwRWC, NULL); // Animation Frame;
 	WriteFile(hFile, &m_fFrmStart, 4, &dwRWC, NULL); // 전체 프레임.
 	WriteFile(hFile, &m_fFrmEnd, 4, &dwRWC, NULL); // 전체 프레임.
-
-	int i = 0, nL = 0;
 	
 	WriteFile(hFile, &m_nCameraCount, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < m_nCameraCount; i++)
+	for(int i = 0; i < m_nCameraCount; i++)
 	{
-		nL = m_pCameras[i]->FileName().size();
+		int nL = m_pCameras[i]->FileName().size();
 		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
 		WriteFile(hFile, m_pCameras[i]->FileName().c_str(), nL, &dwRWC, NULL);
 		m_pCameras[i]->SaveToFile();
 	}
 
 	WriteFile(hFile, &m_nLightCount, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < m_nLightCount; i++) 
+	for(int i = 0; i < m_nLightCount; i++) 
 	{
-		nL = m_pLights[i]->FileName().size();
+		int nL = m_pLights[i]->FileName().size();
 		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
 		WriteFile(hFile, m_pLights[i]->FileName().c_str(), nL, &dwRWC, NULL);
 		m_pLights[i]->SaveToFile();
@@ -194,9 +190,9 @@ bool CN3Scene::Save(HANDLE hFile)
 
 	int iSC = m_Shapes.size();
 	WriteFile(hFile, &iSC, 4, &dwRWC, NULL); // Shapes..
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
-		nL = m_Shapes[i]->FileName().size();
+		int nL = m_Shapes[i]->FileName().size();
 		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
 
@@ -206,9 +202,9 @@ bool CN3Scene::Save(HANDLE hFile)
 
 	int iCC = m_Chrs.size();
 	WriteFile(hFile, &iCC, 4, &dwRWC, NULL); // 캐릭터
-	for(i = 0; i < iCC; i++)
+	for(int i = 0; i < iCC; i++)
 	{
-		nL = m_Chrs[i]->FileName().size();
+		int nL = m_Chrs[i]->FileName().size();
 		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
 
@@ -223,14 +219,13 @@ bool CN3Scene::Save(HANDLE hFile)
 
 void CN3Scene::Render()
 {
-	int i = 0;
-//	for(i = 0; i < m_nCameraCount; i++)
+//	for(int i = 0; i < m_nCameraCount; i++)
 //	{
 //		__ASSERT(m_pCameras[i], "Camera pointer is NULL");
 //		if(m_nCameraActive != i) m_pCameras[i]->Render();
 //	}
 
-//	for(i = 0; i < m_nLightCount; i++)
+//	for(int i = 0; i < m_nLightCount; i++)
 //	{
 //		__ASSERT(m_pLights[i], "Light pointer is NULL");
 //		m_pLights[i]->Render(NULL, 0.5f);
@@ -238,13 +233,13 @@ void CN3Scene::Render()
 	s_lpD3DDev->SetRenderState(D3DRS_AMBIENT, m_AmbientLightColor);
 
 	int iSC = m_Shapes.size();
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		m_Shapes[i]->Render();
 	}
 
 	int iCC = m_Chrs.size();
-	for(i = 0; i < iCC; i++)
+	for(int i = 0; i < iCC; i++)
 	{
 		m_Chrs[i]->Render();
 	}
@@ -281,7 +276,7 @@ void CN3Scene::TickLights(float fFrm)
 {
 	for(int i = 0; i < 8; i++) s_lpD3DDev->LightEnable(i, FALSE); // 일단 라이트 다 끄고..
 	
-	for(i = 0; i < m_nLightCount; i++)
+	for(int i = 0; i < m_nLightCount; i++)
 	{
 		m_pLights[i]->Tick(m_fFrmCur);
 		m_pLights[i]->Apply(); // 라이트 적용
@@ -498,23 +493,23 @@ bool CN3Scene::CheckOverlappedShapesAndReport()
 	CN3Transform* pShapes[8192];
 	memset(pShapes, 0, 8192*4);
 
-	int i, j, nBC = 0;
-//	for(i = 0; i < m_nCameraCount; i++) pTransforms[nBC++] = m_pCameras[i];
-//	for(i = 0; i < m_nLightCount; i++) pTransforms[nBC++] = m_pLights[i];
+	int nBC = 0;
+//	for(int i = 0; i < m_nCameraCount; i++) pTransforms[nBC++] = m_pCameras[i];
+//	for(int i = 0; i < m_nLightCount; i++) pTransforms[nBC++] = m_pLights[i];
 	it_Shape it = m_Shapes.begin(), itEnd = m_Shapes.end();
 	for(; it != itEnd; it++)
 	{
 		CN3Shape* pShape = *it;
 		pShapes[nBC++] = pShape;
 	}
-//	for(i = 0; i < m_nChrCount; i++) pTransforms[nBC++] = m_pChrs[i];
+//	for(int i = 0; i < m_nChrCount; i++) pTransforms[nBC++] = m_pChrs[i];
 
 	bool bOverlapped = false;
 	__Vector3 vPos1, vPos2;
-	for(i = 0; i < nBC; i++)
+	for(int i = 0; i < nBC; i++)
 	{
 		vPos1 = pShapes[i]->Pos();
-		for(j = i+1; j < nBC; j++)
+		for(int j = i+1; j < nBC; j++)
 		{
 			vPos2 = pShapes[j]->Pos();
 			if(	vPos1 == vPos2 ||
@@ -544,7 +539,7 @@ void CN3Scene::DeleteOverlappedShapes()
 	memset(itShapes, 0, sizeof(itShapes));
 	memset(itShapes, 0, sizeof(pShapes));
 
-	int i, j, nBC = 0;
+	int nBC = 0;
 	it_Shape it = m_Shapes.begin(), itEnd = m_Shapes.end();
 	for(; it != itEnd; it++)
 	{
@@ -553,14 +548,14 @@ void CN3Scene::DeleteOverlappedShapes()
 		CN3Shape* pShape = *it;
 		pShapes[nBC++] = pShape;
 	}
-//	for(i = 0; i < m_nChrCount; i++) pTransforms[nBC++] = m_pChrs[i];
+//	for(int i = 0; i < m_nChrCount; i++) pTransforms[nBC++] = m_pChrs[i];
 
 	int iNeedDeleteCount = 0;
 	__Vector3 vPos1, vPos2;
-	for(i = 0; i < nBC; i++)
+	for(int i = 0; i < nBC; i++)
 	{
 		vPos1 = pShapes[i]->Pos();
-		for(j = i+1; j < nBC; j++)
+		for(int j = i+1; j < nBC; j++)
 		{
 			vPos2 = pShapes[j]->Pos();
 			if(	vPos1 == vPos2 ||
@@ -571,7 +566,7 @@ void CN3Scene::DeleteOverlappedShapes()
 		}
 	}
 
-	for(i = 0; i < nBC; i++)
+	for(int i = 0; i < nBC; i++)
 	{
 		if(bNeedDeletes[i])
 		{

--- a/src/engine/N3Base/N3Shape.cpp
+++ b/src/engine/N3Base/N3Shape.cpp
@@ -957,7 +957,7 @@ bool CN3Shape::MakeCollisionMeshByParts()  // 충돌 메시를 박스로 만든다...
 	CN3VMesh VMTmp;
 
 	iVC = 0; iIC = 0;
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		CN3PMesh* pPMesh = m_Parts[i]->Mesh();
 		if(NULL == pPMesh) continue;
@@ -971,7 +971,7 @@ bool CN3Shape::MakeCollisionMeshByParts()  // 충돌 메시를 박스로 만든다...
 		__Matrix44 mtxPart = m_Parts[i]->m_Matrix;
 		mtxPart *= mtxI;
 		for(int j = 0; j < 8; j++) pVDest[iVC+j] = pVSrc[j] * mtxPart;
-		for(j = 0; j < 36; j++) pwIDest[iIC+j] = pwISrc[j] + iVC;
+		for(int j = 0; j < 36; j++) pwIDest[iIC+j] = pwISrc[j] + iVC;
 
 		iVC += 8;
 		iIC += 36;
@@ -1031,7 +1031,7 @@ bool CN3Shape::MakeCollisionMeshByPartsDetail()  // 현재 모습 그대로... 충돌 메�
 	__Matrix44 mtxI = m_Matrix;
 	D3DXMatrixInverse(&mtxI, NULL, &m_Matrix);
 
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		CN3PMesh* pPMesh = m_Parts[i]->Mesh();
 		CN3PMeshInstance* pPMI = m_Parts[i]->MeshInstance();
@@ -1048,7 +1048,7 @@ bool CN3Shape::MakeCollisionMeshByPartsDetail()  // 현재 모습 그대로... 충돌 메�
 		__Matrix44 mtxPart = m_Parts[i]->m_Matrix;
 		mtxPart *= mtxI;
 		for(int j = 0; j < iMaxNumVertices; j++) pVDest[iVC+j] = pVSrc[j] * mtxPart;
-		for(j = 0; j < iMaxNumIndices; j++) pwIDest[iIC+j] = pwISrc[j] + iVC;
+		for(int j = 0; j < iMaxNumIndices; j++) pwIDest[iIC+j] = pwISrc[j] + iVC;
 
 		iVC += iMaxNumVertices;
 		iIC += iMaxNumIndices;
@@ -1122,7 +1122,7 @@ bool CN3Shape::SaveToSameFolder(const std::string& szFullPath)
 	int iPC = m_Parts.size();
 	std::vector<std::string> OldPartFNs;
 	std::vector<std::string> OldTexFNs;
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		szOldFN = m_Parts[i]->Mesh()->FileName();
 		OldPartFNs.push_back(szOldFN); // 파일 이름 보관..
@@ -1154,7 +1154,7 @@ bool CN3Shape::SaveToSameFolder(const std::string& szFullPath)
 	// 원래대로 파일 이름 돌려놓기..
 	iPC = m_Parts.size();
 	int iSeq = 0;
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		m_Parts[i]->Mesh()->FileNameSet(OldPartFNs[i]);
 
@@ -1197,7 +1197,7 @@ bool CN3Shape::SaveToSameFolderAndMore(const std::string& szFullPath, const std:
 	std::string szNameTmp, szOldFN;
 
 	int iPC = m_Parts.size();
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		szOldFN = m_Parts[i]->Mesh()->FileName();
 

--- a/src/engine/N3Base/N3ShapeEx.cpp
+++ b/src/engine/N3Base/N3ShapeEx.cpp
@@ -171,7 +171,6 @@ void CN3ShapeEx::Tick(float fFrm)
 	CN3Shape::Tick(fFrm);
 	if (m_bDontRender) return;
 
-	int i;
 	if (m_fActionTimeChanged > 0.0f)
 	{
 		m_fActionTimeChanging += s_fSecPerFrm;
@@ -181,7 +180,7 @@ void CN3ShapeEx::Tick(float fFrm)
 			m_fActionTimeChanging = 0.0f;
 			m_iPrevActionState = m_iCurActionState;
 
-			for (i=0; i<m_iActionPartCount; ++i)
+			for (int i=0; i<m_iActionPartCount; ++i)
 			{
 				m_pActionParts[i].CurStateInfo = m_pActionParts[i].pStateInfos[m_iCurActionState];
 			}
@@ -189,7 +188,7 @@ void CN3ShapeEx::Tick(float fFrm)
 		else
 		{
 			__ActionPart* pMP = NULL;
-			for (i=0; i<m_iActionPartCount; ++i)
+			for (int i=0; i<m_iActionPartCount; ++i)
 			{
 				pMP = m_pActionParts + i;
 				if (pMP->bPos)

--- a/src/engine/N3Base/N3ShapeMgr.cpp
+++ b/src/engine/N3Base/N3ShapeMgr.cpp
@@ -316,7 +316,7 @@ void CN3ShapeMgr::GenerateCollisionData()
 	memset(m_pvCollisions, 0, sizeof(__Vector3) * nFC * 3);
 
 	int nCPC = 0; // Collision Polygon Count
-	for(i = 0; i < iSC; i++) // Shape 에 있는 충돌 메시 만큼 데이터 복사..
+	for(int i = 0; i < iSC; i++) // Shape 에 있는 충돌 메시 만큼 데이터 복사..
 	{
 		CN3VMesh* pVMesh = m_Shapes[i]->CollisionMesh();
 		if (NULL == pVMesh) continue;
@@ -357,7 +357,7 @@ void CN3ShapeMgr::GenerateCollisionData()
 	// 각 선분이 셀에 걸쳐 있는지 혹은 포함되어 있는지 등등 판단해서 인덱스 생성을 한다.
 	int xSMax = (int)(m_fMapWidth / CELL_SUB_SIZE);
 	int zSMax = (int)(m_fMapLength / CELL_SUB_SIZE);
-	for(i = 0; i < nFC; i++)
+	for(int i = 0; i < nFC; i++)
 	{
 		__Vector3 vEdge[3][2];
 
@@ -615,8 +615,6 @@ void CN3ShapeMgr::Tick()
 	int zMainS = (int)((s_CameraData.vEye.z - s_CameraData.fFP) / CELL_MAIN_SIZE); if(zMainS < 0) zMainS = 0;
 	int zMainE = (int)((s_CameraData.vEye.z + s_CameraData.fFP) / CELL_MAIN_SIZE); if(zMainE > MAX_CELL_MAIN) zMainE = MAX_CELL_MAIN;
 	
-	__CellMain* pCellCur = NULL;
-	int i = 0, iShp = 0, iSIndex = 0, iSC = m_Shapes.size();;
 	m_ShapesToRender.clear();
 	// 렌더링 리스트 비우고..
 	
@@ -624,14 +622,14 @@ void CN3ShapeMgr::Tick()
 	{
 		for(int xM = xMainS; xM < xMainE; xM++)
 		{
-			pCellCur = m_pCells[xM][zM];
+			__CellMain* pCellCur = m_pCells[xM][zM];
 			if(NULL == pCellCur) continue;
 
 			int iSCC = pCellCur->nShapeCount;
-			for(i = 0; i < iSCC; i++)
+			for(int i = 0; i < iSCC; i++)
 			{
-				iSIndex = pCellCur->pwShapeIndices[i];
-				__ASSERT(iSIndex >= 0 && iSIndex < iSC, "Shape Index is invalid");
+				int iSIndex = pCellCur->pwShapeIndices[i];
+				__ASSERT(iSIndex >= 0 && iSIndex < m_Shapes.size(), "Shape Index is invalid");
 
 				m_Shapes[iSIndex]->Tick();
 				if(m_Shapes[iSIndex]->m_bDontRender) continue;
@@ -732,9 +730,7 @@ bool CN3ShapeMgr::CheckCollision(	const __Vector3& vPos,		// 충돌 위치
 	else
 	{
 		it_Shp it = m_ShapesToRender.begin(), itEnd = m_ShapesToRender.end(); // 눈에 보이는것만 대상으로 해서...
-		int iSC = m_ShapesToRender.size();	
-
-		if(iSC > 0)
+		if(m_ShapesToRender.size() > 0)
 		{
 			// 거리순으로 정렬..
 			CN3Shape* pShape = NULL;
@@ -750,11 +746,11 @@ bool CN3ShapeMgr::CheckCollision(	const __Vector3& vPos,		// 충돌 위치
 
 			if(Shapes.empty()) return false;
 
-			iSC = Shapes.size();
+			int iSC = Shapes.size();
 			if(iSC > 1) qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance); // 카메라 거리에 따라 정렬하고..
 
 			CN3VMesh* pVMesh = NULL;
-			for(i = 0; i < iSC; i++)
+			for(int i = 0; i < iSC; i++)
 			{
 				pVMesh = Shapes[i]->CollisionMesh();
 				if(true == pVMesh->CheckCollision(Shapes[i]->m_Matrix, vPos, vPosNext, pvCol, pvNormal)) return true;
@@ -868,7 +864,7 @@ CN3Shape* CN3ShapeMgr::Pick(int iXScreen, int iYScreen, bool bMustHaveEvent, __V
 	for(int i = 0; it != itEnd; it++, i++) { Shapes[i] = *it; }
 	qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance);
 
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		if(bMustHaveEvent && Shapes[i]->m_iEventID <= 0) continue; // 이벤트가 있어야 한다면...
 		if(Shapes[i]->CheckCollisionPrecisely(false, vPos, vDir, pvPick) >= 0)
@@ -895,7 +891,7 @@ CN3Shape* CN3ShapeMgr::PickMovable(int iXScreen, int iYScreen, __Vector3* pvPick
 	for(int i = 0; it != itEnd; it++, i++) { Shapes[i] = *it; }
 	qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance);
 
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		if(Shapes[i]->CheckCollisionPrecisely(false, vPos, vDir, pvPick) >= 0)
 			return Shapes[i];

--- a/src/engine/N3Base/N3ShapeMod.cpp
+++ b/src/engine/N3Base/N3ShapeMod.cpp
@@ -77,12 +77,11 @@ BOOL CN3ShapeMod::LoadStateInfo(FILE* stream)	// »óÅÂ Á¤º¸¸¦ ÀÐ¾î¿Â´Ù.(text·ÎºÎÅ
 	result = fscanf(stream, "State_Count=%d\n", &m_iStateCount);		__ASSERT(result != EOF, "Àß¸øµÈ N3ShapeMod ¼¼ÆÃ ÆÄÀÏ");
 
 	// Shape »óÅÂ Á¤º¸ ÀÐ¾î¿À±â
-	int i, j;
 	__Vector3 vPos, vScale;
 	__Vector3 vAxis;	float fDegree;
 	__Quaternion qRot;
 //	m_ModShape.pShapeStateInfos = new __ModPosRotScale[m_iStateCount];
-//	for (i=0; i<m_iStateCount; ++i)
+//	for (int i=0; i<m_iStateCount; ++i)
 //	{
 //		result = fscanf(stream, "S_Pos(%f, %f, %f)\n", &vPos.x, &vPos.y, &vPos.z);		__ASSERT(result != EOF, "Àß¸øµÈ N3ShapeMod ¼¼ÆÃ ÆÄÀÏ");
 //		result = fscanf(stream, "S_Rot(%f, %f, %f)\n", &vRot.x, &vRot.y, &vRot.z);		__ASSERT(result != EOF, "Àß¸øµÈ N3ShapeMod ¼¼ÆÃ ÆÄÀÏ");
@@ -98,12 +97,12 @@ BOOL CN3ShapeMod::LoadStateInfo(FILE* stream)	// »óÅÂ Á¤º¸¸¦ ÀÐ¾î¿Â´Ù.(text·ÎºÎÅ
 	m_pModParts = new __ModPart[m_iModPartCount];
 
 	char szPMeshName[_MAX_PATH] = "";
-	for (i=0; i<m_iModPartCount; ++i)
+	for (int i=0; i<m_iModPartCount; ++i)
 	{
 		result = fscanf(stream, "PMesh_FName=%s\n", szPMeshName);		__ASSERT(result != EOF, "Àß¸øµÈ N3ShapeMod ¼¼ÆÃ ÆÄÀÏ");
 		m_pModParts[i].pPart = GetPartByPMeshFileName(szPMeshName);
 		m_pModParts[i].pStateInfos = new __ModPosRotScale[m_iStateCount];
-		for (j=0; j<m_iStateCount; ++j)
+		for (int j=0; j<m_iStateCount; ++j)
 		{
 			result = fscanf(stream, "Pos(%f, %f, %f)\n", &vPos.x, &vPos.y, &vPos.z);		__ASSERT(result != EOF, "Àß¸øµÈ N3ShapeMod ¼¼ÆÃ ÆÄÀÏ");
 			result = fscanf(stream, "Rot(%f, %f, %f, %f)\n", &vAxis.x, &vAxis.y, &vAxis.z, &fDegree);		__ASSERT(result != EOF, "Àß¸øµÈ N3ShapeMod ¼¼ÆÃ ÆÄÀÏ");
@@ -131,7 +130,7 @@ BOOL CN3ShapeMod::LoadStateInfo(FILE* stream)	// »óÅÂ Á¤º¸¸¦ ÀÐ¾î¿Â´Ù.(text·ÎºÎÅ
 	if (iPartCount>0) m_pMatchPart2ModPart = new __ModPart*[iPartCount];
 	ZeroMemory(m_pMatchPart2ModPart, sizeof(m_pMatchPart2ModPart[0])*iPartCount);
 	// (¸ÅÄª½ÃÅ°±â)
-	for(i=0; i<m_iModPartCount; ++i)
+	for(int i=0; i<m_iModPartCount; ++i)
 	{
 		it_SPart it = m_Parts.begin();
 		int iPC = m_Parts.size();
@@ -183,7 +182,6 @@ void CN3ShapeMod::Tick(float fFrm)
 	CN3Shape::Tick(fFrm);
 	if (m_bDontRender) return;
 
-	int i;
 	if (m_fTimeChanged > 0.0f)
 	{
 		m_fTimeChanging += s_fSecPerFrm;
@@ -193,7 +191,7 @@ void CN3ShapeMod::Tick(float fFrm)
 			m_fTimeChanging = 0.0f;
 			m_iPrevState = m_iCurState;
 
-			for (i=0; i<m_iModPartCount; ++i)
+			for (int i=0; i<m_iModPartCount; ++i)
 			{
 				m_pModParts[i].CurStateInfo = m_pModParts[i].pStateInfos[m_iCurState];
 			}
@@ -201,7 +199,7 @@ void CN3ShapeMod::Tick(float fFrm)
 		else
 		{
 			__ModPart* pMP = NULL;
-			for (i=0; i<m_iModPartCount; ++i)
+			for (int i=0; i<m_iModPartCount; ++i)
 			{
 				pMP = m_pModParts + i;
 				if (pMP->bPos)

--- a/src/engine/N3Base/N3Skin.cpp
+++ b/src/engine/N3Base/N3Skin.cpp
@@ -107,14 +107,13 @@ int CN3Skin::SortWeightsProc(const void *pArg1, const void *pArg2)
 void CN3Skin::RecalcWeight()
 {
 	if (NULL == m_pSkinVertices) return;
-	int i, j;
-	for (i=0; i<m_nVC; ++i)
+	for (int i=0; i<m_nVC; ++i)
 	{
 		__VertexSkinned* pVtx = m_pSkinVertices + i;
 		if (1 >= pVtx->nAffect) continue;
 		float fSum = 0;
-		for (j=0; j<pVtx->nAffect; ++j) fSum += pVtx->pfWeights[j];
-		for (j=0; j<pVtx->nAffect; ++j) pVtx->pfWeights[j] /= fSum;
+		for (int j=0; j<pVtx->nAffect; ++j) fSum += pVtx->pfWeights[j];
+		for (int j=0; j<pVtx->nAffect; ++j) pVtx->pfWeights[j] /= fSum;
 	}
 }
 

--- a/src/engine/N3Base/N3Sky.cpp
+++ b/src/engine/N3Base/N3Sky.cpp
@@ -39,9 +39,8 @@ void CN3Sky::Tick()
 {
 	m_SkyColor.Tick();
 	m_FogColor.Tick();
-	int i;
 	D3DCOLOR FogColor = m_FogColor.GetCurColor();
-	for (i=0; i<4; ++i)
+	for (int i=0; i<4; ++i)
 	{
 		m_vFronts[i].color = (m_vFronts[i].color&0xff000000) | (FogColor&0x00ffffff);
 		m_Bottom[i].color = FogColor;

--- a/src/engine/N3Base/N3SkyMng.cpp
+++ b/src/engine/N3Base/N3SkyMng.cpp
@@ -166,10 +166,9 @@ void CN3SkyMng::Render()
 
 void CN3SkyMng::RenderWeather()
 {
-	int i, j;
-	for (i=0; i<3; ++i)
+	for (int i=0; i<3; ++i)
 	{
-		for(j=0; j<3; ++j)
+		for(int j=0; j<3; ++j)
 		{
 			if (m_pGERain)
 			{
@@ -292,9 +291,8 @@ void CN3SkyMng::Tick()
 		if (NewCellPos.x != m_CurCellPos.x || NewCellPos.y != m_CurCellPos.y)
 		{
 			m_CurCellPos = NewCellPos;
-			int i, j;
-			for(i=0; i<3; ++i)
-				for(j=0; j<3; ++j)
+			for(int i=0; i<3; ++i)
+				for(int j=0; j<3; ++j)
 					m_vPos[j*3+i].Set( (m_CurCellPos.x+i-0.5f)*m_fCellSize, 0, (m_CurCellPos.y+j-0.5f)*m_fCellSize);
 		}
 
@@ -376,7 +374,7 @@ bool CN3SkyMng::LoadFromTextFile(const char* szIniFN)
 		}
 	}
 
-	for(i = 0 ; i < NUM_CLOUD; i++)
+	for(int i = 0 ; i < NUM_CLOUD; i++)
 	{
 		pResult = fgets(szLine, 512, fp);
 		if(pResult)
@@ -426,7 +424,7 @@ bool CN3SkyMng::LoadFromTextFile(const char* szIniFN)
 	if(NULL == m_pMoon) m_pMoon = new CN3Moon();
 	m_pMoon->Init(szMoon);
 
-	for(i = 0; i < MAX_GAME_LIGHT; i++)
+	for(int i = 0; i < MAX_GAME_LIGHT; i++)
 	{
 		if(NULL == m_pLightColorDiffuses[i]) m_pLightColorDiffuses[i] = new CN3ColorChange();
 		if(NULL == m_pLightColorAmbients[i]) m_pLightColorAmbients[i] = new CN3ColorChange();
@@ -455,14 +453,13 @@ bool CN3SkyMng::SaveToTextFile(const char* szIniFN)
 	else fprintf(fp, "Moon : \r\n");
 	
 
-	int i = 0;
-	for(i = 0; i < NUM_SUNPART; i++) 
+	for(int i = 0; i < NUM_SUNPART; i++) 
 	{
 		if(this->SunTextureGet(i)) fprintf(fp, "Sun : %s\r\n", this->SunTextureGet(i)->FileName().c_str());
 		else fprintf(fp, "Sun : \r\n");
 	}
 
-	for(i = 0; i < NUM_CLOUD; i++) 
+	for(int i = 0; i < NUM_CLOUD; i++) 
 	{
 		if(this->CloudTextureFileName(i)) fprintf(fp, "Cloud : %s\r\n", this->CloudTextureFileName(i));
 		else fprintf(fp, "Cloud : \r\n");
@@ -471,7 +468,7 @@ bool CN3SkyMng::SaveToTextFile(const char* szIniFN)
 
 	int iDC = m_DayChanges.size();
 	fprintf(fp, "DayChange Count : %d\r\n", iDC);
-	for(i = 0; i < iDC; i++)
+	for(int i = 0; i < iDC; i++)
 	{
 		this->DayChangeWrite(fp, &(m_DayChanges[i]));
 	}
@@ -692,8 +689,7 @@ void CN3SkyMng::SetCheckGameTime(DWORD dwCheckGameTime)
 	if (m_iDayChangeCurPos >= iDCC) m_iDayChangeCurPos = iDCC - 1;
 
 	// 현재 게임시간에서 각 sky상태별로 가장 최근에 변경된 값을 찾아서 값을 지정해준다.
-	int i;
-	for(i=0; i<NUM_SKYDAYCHANGE; ++i)
+	for(int i=0; i<NUM_SKYDAYCHANGE; ++i)
 	{
 		if (i == SDC_MOONPHASE) continue;
 
@@ -1236,8 +1232,7 @@ bool CN3SkyMng::Load(HANDLE hFile)
 	std::string szClouds[NUM_CLOUD];
 	std::string szMoon;
 
-	int i = 0;
-	for(i = 0; i < NUM_SUNPART; i++) 
+	for(int i = 0; i < NUM_SUNPART; i++) 
 	{
 		int iL = 0;
 		ReadFile(hFile, &iL, 4, &dwRWC, NULL);
@@ -1248,7 +1243,7 @@ bool CN3SkyMng::Load(HANDLE hFile)
 		}
 	}
 
-	for(i = 0; i < NUM_CLOUD; i++) 
+	for(int i = 0; i < NUM_CLOUD; i++) 
 	{
 		int iL = 0;
 		ReadFile(hFile, &iL, 4, &dwRWC, NULL);
@@ -1282,7 +1277,7 @@ bool CN3SkyMng::Load(HANDLE hFile)
 	if(NULL == m_pMoon) m_pMoon = new CN3Moon();
 	m_pMoon->Init(szMoon);
 
-	for(i = 0; i < MAX_GAME_LIGHT; i++)
+	for(int i = 0; i < MAX_GAME_LIGHT; i++)
 	{
 		if(NULL == m_pLightColorDiffuses[i]) m_pLightColorDiffuses[i] = new CN3ColorChange();
 		if(NULL == m_pLightColorAmbients[i]) m_pLightColorAmbients[i] = new CN3ColorChange();
@@ -1295,7 +1290,7 @@ bool CN3SkyMng::Load(HANDLE hFile)
 	if(iSDCC > 0)
 	{
 		m_DayChanges.resize(iSDCC);
-		for(i = 0; i < iSDCC; i++)
+		for(int i = 0; i < iSDCC; i++)
 		{
 			m_DayChanges[i].Load(hFile);
 		}
@@ -1316,19 +1311,18 @@ bool CN3SkyMng::Save(HANDLE hFile)
 	std::string szClouds[NUM_CLOUD];
 	std::string szMoon;
 
-	int i = 0;
-	for(i = 0; i < NUM_SUNPART; i++) if(m_pSun && m_pSun->m_Parts[i].pTex) szSuns[i] = m_pSun->m_Parts[i].pTex->FileName();
-	for(i = 0; i < NUM_CLOUD; i++) if(m_pCloud) szClouds[i] = m_pCloud->m_szTextures[i];
+	for(int i = 0; i < NUM_SUNPART; i++) if(m_pSun && m_pSun->m_Parts[i].pTex) szSuns[i] = m_pSun->m_Parts[i].pTex->FileName();
+	for(int i = 0; i < NUM_CLOUD; i++) if(m_pCloud) szClouds[i] = m_pCloud->m_szTextures[i];
 	if(m_pMoon && m_pMoon->m_pTexture) szMoon = m_pMoon->m_pTexture->FileName();
 
-	for(i = 0; i < NUM_SUNPART; i++) 
+	for(int i = 0; i < NUM_SUNPART; i++) 
 	{
 		int iL = szSuns[i].size();
 		WriteFile(hFile, &iL, 4, &dwRWC, NULL);
 		if(iL > 0) WriteFile(hFile, szSuns[i].c_str(), iL, &dwRWC, NULL);
 	}
 
-	for(i = 0; i < NUM_CLOUD; i++)
+	for(int i = 0; i < NUM_CLOUD; i++)
 	{
 		int iL = szClouds[i].size();
 		WriteFile(hFile, &iL, 4, &dwRWC, NULL);
@@ -1342,7 +1336,7 @@ bool CN3SkyMng::Save(HANDLE hFile)
 	// Day Change .....
 	int iSDCC = m_DayChanges.size();
 	WriteFile(hFile, &iSDCC, 4, &dwRWC, NULL);
-	for(i = 0; i < iSDCC; i++)
+	for(int i = 0; i < iSDCC; i++)
 	{
 		m_DayChanges[i].Save(hFile);
 	}

--- a/src/engine/N3Base/N3Star.cpp
+++ b/src/engine/N3Base/N3Star.cpp
@@ -81,12 +81,11 @@ void CN3Star::Init()
 {
 	Release();
 
-	int i;
 	BYTE alpha = 0xff;
 	BYTE alpha_min = 0x80;
 	BYTE alpha_max = 0xff;
 	float fInc = ((float)(alpha_max - alpha_min))/MAX_STAR;
-	for (i=0; i<MAX_STAR; ++i)
+	for (int i=0; i<MAX_STAR; ++i)
 	{
 		float fX = ((float)(rand()%10000))/1000.f - 5.0f;
 		float fY = ((float)(rand()%10000))/1000.f - 2.0f;

--- a/src/engine/N3Base/N3Sun.cpp
+++ b/src/engine/N3Base/N3Sun.cpp
@@ -14,8 +14,7 @@
 CN3Sun::CN3Sun()
 {
 	memset(m_Parts, 0, sizeof(__SunPart)*NUM_SUNPART);
-	int i;
-	for(i=0; i<NUM_SUNPART; ++i)
+	for(int i=0; i<NUM_SUNPART; ++i)
 	{
 		m_Parts[i].Color.ChangeColor(0xffffffff);
 	}
@@ -24,8 +23,7 @@ CN3Sun::CN3Sun()
 
 CN3Sun::~CN3Sun()
 {
-	int i;
-	for(i=0; i<NUM_SUNPART; ++i)
+	for(int i=0; i<NUM_SUNPART; ++i)
 	{
 		__SunPart* pSP = m_Parts+i;
 		s_MngTex.Delete(&(pSP->pTex));
@@ -37,8 +35,7 @@ void CN3Sun::Release()
 	CN3Base::Release();
 	
 	memset(m_Parts, 0, sizeof(__SunPart) * NUM_SUNPART);
-	int i;
-	for(i=0; i<NUM_SUNPART; ++i)
+	for(int i=0; i<NUM_SUNPART; ++i)
 	{
 		s_MngTex.Delete(&m_Parts[i].pTex);
 		m_Parts[i].Color.ChangeColor(0xffffffff);
@@ -118,8 +115,7 @@ void CN3Sun::Render(__Matrix44& matView, __Matrix44& matProj)
 void CN3Sun::Tick()
 {
 	// 해의 색, 크기 변화 계산
-	int i;
-	for(i=0; i<NUM_SUNPART; ++i)
+	for(int i=0; i<NUM_SUNPART; ++i)
 	{
 		m_Parts[i].Color.Tick();
 		m_Parts[i].Delta.Tick();

--- a/src/engine/N3Base/N3TableBase.h
+++ b/src/engine/N3Base/N3TableBase.h
@@ -389,7 +389,7 @@ BOOL CN3TableBase<Type>::Load(HANDLE hFile)
 
 	// data(column) 의 구조가 어떻게 되어 있는지 읽기
 	DWORD dwNum;
-	int i, j, iDataTypeCount = 0;
+	int iDataTypeCount = 0;
 	ReadFile(hFile, &iDataTypeCount, 4, &dwNum, NULL);			// (엑셀에서 column 수)
 
 	std::vector<int> offsets;
@@ -419,9 +419,9 @@ BOOL CN3TableBase<Type>::Load(HANDLE hFile)
 	int iRC;
 	ReadFile(hFile, &iRC, sizeof(iRC), &dwNum, NULL);
 	Type Data;
-	for (i=0; i<iRC; ++i)
+	for (int i=0; i<iRC; ++i)
 	{
-		for (j=0; j<iDataTypeCount; ++j)
+		for (int j=0; j<iDataTypeCount; ++j)
 		{
 			ReadData(hFile, m_DataTypes[j], (char*)(&Data) + offsets[j]);
 		}
@@ -469,12 +469,12 @@ BOOL CN3TableBase<Type>::MakeOffsetTable(std::vector<int>& offsets)
 {	
 	if (m_DataTypes.empty()) return false;
 
-	int i, iDataTypeCount = m_DataTypes.size();
+	int iDataTypeCount = m_DataTypes.size();
 	offsets.clear();
 	offsets.reserve(iDataTypeCount+1);	// +1을 한 이유는 맨 마지막 값에 Type의 실제 사이즈를 넣기 위해서
 	offsets[0] = 0;
 	int iPrevDataSize = SizeOf(m_DataTypes[0]);
-	for (i=1; i<iDataTypeCount; ++i)
+	for (int i=1; i<iDataTypeCount; ++i)
 	{
 		int iCurDataSize = SizeOf(m_DataTypes[i]);
 		if (1 == iCurDataSize%4)	// 현재 데이터가 1바이트면 그냥 이전 데이터가 몇바이트든 상관 없다.

--- a/src/engine/N3Base/N3Texture.cpp
+++ b/src/engine/N3Base/N3Texture.cpp
@@ -57,8 +57,9 @@ bool CN3Texture::Create(int nWidth, int nHeight, D3DFORMAT Format, BOOL bGenerat
 
 	if(s_dwTextureCaps & TEX_CAPS_POW2) // 2 의 승수만 된다면..
 	{
-		for(int nW = 1; nW <= nWidth; nW *= 2); nW /= 2;
-		for(int nH = 1; nH <= nHeight; nH *= 2); nH /= 2;
+		int nW = 1, nH = 1;
+		for(; nW <= nWidth; nW *= 2); nW /= 2;
+		for(; nH <= nHeight; nH *= 2); nH /= 2;
 
 		nWidth = nW;
 		nHeight = nH;
@@ -624,7 +625,7 @@ bool CN3Texture::Save(HANDLE hFile)
 		
 		int nMMC2 = nMMC - 1;
 		if(nMMC == 1) nMMC2 = nMMC;
-		for(i = 0; i < nMMC2; i++)
+		for(int i = 0; i < nMMC2; i++)
 		{
 			m_lpTexture->GetLevelDesc(i, &sd);
 			m_lpTexture->GetSurfaceLevel(i, &lpSurfSrc);

--- a/src/engine/N3Base/N3UIButton.cpp
+++ b/src/engine/N3Base/N3UIButton.cpp
@@ -96,10 +96,10 @@ void CN3UIButton::Render()
 		}
 	}
 
-	int i = 0;
 	for(UIListReverseItor itor = m_Children.rbegin(); m_Children.rend() != itor; ++itor)
 	{
 		CN3UIBase* pChild = (*itor);
+		int i;
 		for(i = 0; i < NUM_BTN_STATE; i++) // 버튼의 구성 요소가 아닌지 보고..
 			if(pChild == m_ImageRef[i]) break;
 		if(i >= NUM_BTN_STATE) pChild->Render(); // 버튼 차일드가 아니면 렌더링..
@@ -330,8 +330,7 @@ bool CN3UIButton::Save(HANDLE hFile)
 // 툴에서 사용하기 위한 함수 : n3uiImage를 생성한다.
 void CN3UIButton::CreateImages()
 {
-	int i;
-	for (i=0; i<NUM_BTN_STATE; ++i)
+	for (int i=0; i<NUM_BTN_STATE; ++i)
 	{
 		__ASSERT(NULL == m_ImageRef[i],"이미지가 이미 할당되어 있어여");
 		m_ImageRef[i] = new CN3UIImage();

--- a/src/engine/N3Base/N3UIImage.cpp
+++ b/src/engine/N3Base/N3UIImage.cpp
@@ -186,8 +186,7 @@ void CN3UIImage::SetColor(D3DCOLOR color)
 	m_Color = color;
 	if ((UISTYLE_IMAGE_ANIMATE & m_dwStyle) && m_pAnimImagesRef)
 	{
-		int i;
-		for(i=0; i<m_iAnimCount; ++i) m_pAnimImagesRef[i]->SetColor(color);
+		for(int i=0; i<m_iAnimCount; ++i) m_pAnimImagesRef[i]->SetColor(color);
 	}
 	SetVB();
 }
@@ -327,8 +326,7 @@ void CN3UIImage::ReorderChildImage()
 	CN3UIBase** pNewList = new CN3UIBase*[m_iAnimCount];
 	ZeroMemory(pNewList, sizeof(CN3UIBase*)*m_iAnimCount);
 
-	int i;
-	for (i=0; i<m_iAnimCount; ++i)
+	for (int i=0; i<m_iAnimCount; ++i)
 	{
 		CN3UIBase* pSelChild = NULL;
 		for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
@@ -343,7 +341,7 @@ void CN3UIImage::ReorderChildImage()
 		RemoveChild(pSelChild);
 	}
 	
-	for (i=0; i<m_iAnimCount; ++i) m_Children.push_back(pNewList[i]);	// 작은 순서대로 넣기
+	for (int i=0; i<m_iAnimCount; ++i) m_Children.push_back(pNewList[i]);	// 작은 순서대로 넣기
 
 	delete [] pNewList;
 }
@@ -357,10 +355,9 @@ CN3UIImage* CN3UIImage::GetChildImage(int iIndex)
 void CN3UIImage::SetAnimImage(int iAnimCount)
 {
 	// 이미 설정 되어 있는것이 있으면 지우기
-	int i;
 	if (m_pAnimImagesRef)
 	{
-		for (i=0; i<m_iAnimCount; ++i)
+		for (int i=0; i<m_iAnimCount; ++i)
 		{	// 자식 지우기
 			if (m_pAnimImagesRef[i]) {delete m_pAnimImagesRef[i]; m_pAnimImagesRef[i] = NULL;}
 		}
@@ -383,7 +380,7 @@ void CN3UIImage::SetAnimImage(int iAnimCount)
 
 		m_pAnimImagesRef = new CN3UIImage*[m_iAnimCount];
 		ZeroMemory(m_pAnimImagesRef, sizeof(CN3UIImage*)*m_iAnimCount);
-		for (i=0; i<m_iAnimCount; ++i)
+		for (int i=0; i<m_iAnimCount; ++i)
 		{
 			m_pAnimImagesRef[i] = new CN3UIImage();
 			m_pAnimImagesRef[i]->Init(this);

--- a/src/engine/N3Base/N3UIManager.cpp
+++ b/src/engine/N3Base/N3UIManager.cpp
@@ -80,8 +80,7 @@ void CN3UIManager::ReorderChildList()	// 다이알로그 순서 재배치
 		}
 		else ++itor;
 	}
-	int i;
-	for (i=iAlwaysTopChildCount-1; i>=0; --i)
+	for (int i=iAlwaysTopChildCount-1; i>=0; --i)
 	{
 		m_Children.push_front(ppBuffer[i]);	// 맨앞에 넣는다. 그리는 순서를 맨 나중에 그리도록 하고 메세지를 맨 먼저 받게 하려고
 	}

--- a/src/engine/N3Base/N3UIScrollBar.cpp
+++ b/src/engine/N3Base/N3UIScrollBar.cpp
@@ -122,8 +122,7 @@ void CN3UIScrollBar::operator = (const CN3UIScrollBar& other)
 void CN3UIScrollBar::CreateTrackBarAndBtns()
 {
 	__ASSERT(NULL == m_pTrackBarRef, "구성요소가 이미 할당되어 있어요");
-	int i;
-	for (i=0; i<NUM_BTN_TYPE; ++i)
+	for (int i=0; i<NUM_BTN_TYPE; ++i)
 	{
 		m_pBtnRef[i] = new CN3UIButton();
 		m_pBtnRef[i]->Init(this);

--- a/src/engine/N3Base/N3UITooltip.cpp
+++ b/src/engine/N3Base/N3UITooltip.cpp
@@ -64,8 +64,7 @@ void CN3UITooltip::Render()
 		HRESULT hr = s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 2, pVB, sizeof(__VertexTransformedColor));	// 배경색 칠하기
 
 		__VertexTransformedColor* pTemp = pVB;
-		int i;
-		for (i=0; i<4; ++i) pTemp++->color = BorderColorOut;	// 바깥 테두리 색을 바꾼다.
+		for (int i=0; i<4; ++i) pTemp++->color = BorderColorOut;	// 바깥 테두리 색을 바꾼다.
 		s_lpD3DDev->DrawIndexedPrimitiveUP(D3DPT_LINELIST, 0, 8, 8, 
 			pIB, D3DFMT_INDEX16, pVB, sizeof(__VertexTransformedColor));	// 테두리 칠하기
 

--- a/src/engine/N3Base/N3VMesh.cpp
+++ b/src/engine/N3Base/N3VMesh.cpp
@@ -290,14 +290,13 @@ bool CN3VMesh::CheckCollision(const __Matrix44& MtxWorld, const __Vector3& v0, c
 
 	//두점이 충돌메시 안에 있는 경우..by lynus..
 	__Vector3 tmpNormal;
-	float d;
-	for(i = 0; i < nFC; i++)
+	for(int i = 0; i < nFC; i++)
 	{
 		if(m_nIC > 0) { nCI0 = m_pwIndices[i*3+0]; nCI1 = m_pwIndices[i*3+1]; nCI2 = m_pwIndices[i*3+2]; }
 		else { nCI0 = i*3; nCI1 = i*3+1; nCI2 = i*3+2; }
 
 		tmpNormal.Cross(m_pVertices[nCI1] - m_pVertices[nCI0], m_pVertices[nCI2] - m_pVertices[nCI1]);
-		d = -(tmpNormal.x*m_pVertices[nCI0].x) - (tmpNormal.y*m_pVertices[nCI0].y) - (tmpNormal.z*m_pVertices[nCI0].z);
+		float d = -(tmpNormal.x*m_pVertices[nCI0].x) - (tmpNormal.y*m_pVertices[nCI0].y) - (tmpNormal.z*m_pVertices[nCI0].z);
 		if( ((tmpNormal.x*vPos0.x)+(tmpNormal.y*vPos0.y)+(tmpNormal.z*vPos0.z)+d) > 0) return false;
 	}
 

--- a/src/game/APISocket.cpp
+++ b/src/game/APISocket.cpp
@@ -246,7 +246,6 @@ int CAPISocket::Connect(HWND hWnd, const char* pszIP, DWORD dwPort)
 	}
 
 	//
-	int i=0;
 	struct sockaddr_in far server;
 	struct hostent far *hp;
   
@@ -314,7 +313,7 @@ int CAPISocket::Connect(HWND hWnd, const char* pszIP, DWORD dwPort)
 	m_bConnected = TRUE;
 	
 #ifdef _DEBUG
-	for(i = 0; i < 255; i++)
+	for(int i = 0; i < 255; i++)
 	{
 		memset(m_Statistics_Send_Sum, 0, sizeof(m_Statistics_Send_Sum));
 		memset(m_Statistics_Recv_Sum, 0, sizeof(m_Statistics_Recv_Sum));

--- a/src/game/BirdMng.cpp
+++ b/src/game/BirdMng.cpp
@@ -48,13 +48,12 @@ void CBirdMng::LoadFromFile(const std::string& szFN)
 		return;
 	}
 
-	int i;
 	char szRrcName[_MAX_PATH];
 	int result = fscanf(stream, "count = %d\n", &m_iBirdCount);			__ASSERT(result != EOF, "肋给等 Machine 技泼 颇老");
 
 	if(m_iBirdCount>0) m_pBird = new CBird[m_iBirdCount];
 
-	for (i=0; i<m_iBirdCount; i++)
+	for (int i=0; i<m_iBirdCount; i++)
 	{
 		result = fscanf(stream, "%s\n", szRrcName);	__ASSERT(result != EOF, "肋给等 bird list 技泼 颇老");
 		m_pBird[i].LoadBird(szRrcName);		

--- a/src/game/GameBase.cpp
+++ b/src/game/GameBase.cpp
@@ -67,7 +67,7 @@ void CGameBase::StaticMemberInit()
 	szFN = "Data\\Quest_Menu" + szLangTail;	s_pTbl_QuestMenu->LoadFromFile(szFN.c_str());	// 퀘스트 관련 선택메뉴
 	szFN = "Data\\Quest_Talk" + szLangTail;	s_pTbl_QuestTalk->LoadFromFile(szFN.c_str());	// 퀘스트 관련 지문
 
-	for(i = 0; i < MAX_ITEM_EXTENSION; i++)
+	for(int i = 0; i < MAX_ITEM_EXTENSION; i++)
 	{
 		char szFNTmp[256] = "";
 		sprintf(szFNTmp, "Data\\Item_Ext_%d", i);

--- a/src/game/GameEng.cpp
+++ b/src/game/GameEng.cpp
@@ -89,24 +89,21 @@ CGameEng::CGameEng()
 CGameEng::~CGameEng()
 {
 	it_Camera itCam = m_Cameras.begin();
-	int iSize = m_Cameras.size();
-	for(int i = 0; i < iSize; i++, itCam++)
+	for(int i = 0; i < m_Cameras.size(); i++, itCam++)
 	{
 		delete *itCam; 
 	}
 	m_Cameras.clear();
 
 /*	it_Light itLgt = m_Lights.begin();
-	iSize = m_Lights.size();
-	for(i = 0; i < iSize; i++, itLgt++)
+	for(int i = 0; i < m_Lights.size(); i++, itLgt++)
 	{
 		delete *itLgt; 
 	}
 	m_Lights.clear();
 
 	itLgt = m_LightsBackup.begin();
-	iSize = m_LightsBackup.size();
-	for(i = 0; i < iSize; i++, itLgt++)
+	for(int i = 0; i < m_LightsBackup.size(); i++, itLgt++)
 	{
 		delete *itLgt; 
 	}

--- a/src/game/GameProcCharacterSelect.cpp
+++ b/src/game/GameProcCharacterSelect.cpp
@@ -30,7 +30,7 @@ CGameProcCharacterSelect::CGameProcCharacterSelect()
 {
 	m_pCamera = NULL;
 	for ( int i = 0; i < 8; i++ ) m_pLights[i] = NULL;
-	for ( i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )	{ m_pChrs[i] = NULL; }
+	for ( int i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )	{ m_pChrs[i] = NULL; }
 	m_pActiveBg = NULL;
 
 	m_eCurPos = POS_CENTER;
@@ -50,7 +50,7 @@ CGameProcCharacterSelect::~CGameProcCharacterSelect()
 {
 	delete m_pCamera;
 	for ( int i = 0; i < 8; i++ ) delete m_pLights[i];
-	for ( i = 0; i < MAX_AVAILABLE_CHARACTER; i++ ) delete m_pChrs[i];
+	for ( int i = 0; i < MAX_AVAILABLE_CHARACTER; i++ ) delete m_pChrs[i];
 	delete m_pActiveBg;
 	delete m_pUICharacterSelect;
 
@@ -63,7 +63,7 @@ void CGameProcCharacterSelect::Release()
 
 	delete m_pCamera; m_pCamera = NULL;
 	for ( int i = 0; i < 8; i++ ) { delete m_pLights[i]; m_pLights[i] = NULL; }
-	for ( i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )
+	for ( int i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )
 	{
 		delete m_pChrs[i]; m_pChrs[i] = NULL;
 		m_InfoChrs[i].clear();
@@ -81,7 +81,7 @@ void CGameProcCharacterSelect::Init()
 //..
 	m_pCamera = NULL;
 	for ( int i = 0; i < 8; i++ ) m_pLights[i] = NULL;
-	for ( i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )	{ m_pChrs[i] = NULL; }
+	for ( int i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )	{ m_pChrs[i] = NULL; }
 	m_pActiveBg = NULL;
 
 	m_eCurPos = POS_CENTER;
@@ -105,8 +105,8 @@ void CGameProcCharacterSelect::Init()
 	s_pUIMgr->EnableOperationSet(false); // 기존의 캐릭터 정보 패킷이 들어올때까지 UI 를 Disable 시킨다...
 
 	m_pCamera = new CN3Camera();
-	for ( i = 0; i < 8; i++ ) m_pLights[i] = new CN3Light();
-	for ( i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )	m_pChrs[i] = NULL;
+	for ( int i = 0; i < 8; i++ ) m_pLights[i] = new CN3Light();
+	for ( int i = 0; i < MAX_AVAILABLE_CHARACTER; i++ )	m_pChrs[i] = NULL;
 
 	m_eCurPos = POS_CENTER;
 	m_eDestPos = POS_CENTER;
@@ -252,7 +252,7 @@ NowRotating:
 // 라이트..
 	for(int i = 0; i < 8; i++) s_pEng->s_lpD3DDev->LightEnable(i, FALSE); // 일단 라이트 다 끄고..
 	
-	for(i = 0; i < 2; i++)
+	for(int i = 0; i < 2; i++)
 	{
 		m_pLights[i]->Tick(m_pLights[i]->m_fFrmCur);
 		m_pLights[i]->Apply(); // 라이트 적용
@@ -1122,7 +1122,7 @@ void CGameProcCharacterSelect::FadeOutRender()
 	if (dwUsefog) CN3Base::s_lpD3DDev->SetRenderState( D3DRS_FOGENABLE, FALSE );
 	// set render states
 	if (dwUseColorVertex == FALSE) CN3Base::s_lpD3DDev->SetRenderState( D3DRS_COLORVERTEX, TRUE );
-	for ( i = 0; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, FALSE);
+	for ( int i = 0; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, FALSE);
 
 	DWORD dwTexStageCO, dwTexStageCARG1, dwTexStageAO, dwTexStageAARG1, dwRSSB, dwRSDB;
 
@@ -1156,7 +1156,7 @@ void CGameProcCharacterSelect::FadeOutRender()
 	CN3Base::s_lpD3DDev->SetRenderState( D3DRS_ALPHABLENDENABLE,		bUseAlphaBlend );
 	CN3Base::s_lpD3DDev->SetRenderState( D3DRS_LIGHTING, dwUseLighting );
 	CN3Base::s_lpD3DDev->SetRenderState( D3DRS_FOGENABLE , dwUsefog );
-	for ( i = 0; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, bLight[i]);
+	for ( int i = 0; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, bLight[i]);
 }
 
 

--- a/src/game/GameProcLogIn.cpp
+++ b/src/game/GameProcLogIn.cpp
@@ -106,7 +106,7 @@ void CGameProcLogIn::Init()
 	int iServerCount = GetPrivateProfileInt("Server", "Count", 0, szIniPath);
 
 	char szIPs[256][32]; memset(szIPs, 0, sizeof(szIPs));
-	for(i = 0; i < iServerCount; i++)
+	for(int i = 0; i < iServerCount; i++)
 	{
 		char szKey[32] = "";
 		sprintf(szKey, "IP%d", i);
@@ -192,7 +192,7 @@ void CGameProcLogIn::Render()
 */
 
 	for(int i = 0; i < 8; i++) 	CN3Base::s_lpD3DDev->LightEnable(i, FALSE);
-	for(i = 0; i < 3; i++) 	m_pLights[i]->Apply();
+	for(int i = 0; i < 3; i++) 	m_pLights[i]->Apply();
 
 	// 라이트 잡기..
 /*	D3DLIGHT9 lgt0, lgt1, lgt2;

--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -1667,7 +1667,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(DataPack* pDataPack, int& iOffset)
 	int iItemDurabilityInSlots[ITEM_SLOT_COUNT]; memset(iItemDurabilityInSlots, -1, sizeof(iItemDurabilityInSlots));
 	int iItemCountInSlots[ITEM_SLOT_COUNT]; memset(iItemCountInSlots, -1, sizeof(iItemCountInSlots));
 
-	for ( i = 0; i < ITEM_SLOT_COUNT; i++ )				// 슬롯 갯수마큼..
+	for ( int i = 0; i < ITEM_SLOT_COUNT; i++ )				// 슬롯 갯수마큼..
 	{
 		iItemIDInSlots[i]			= CAPISocket::Parse_GetDword(pDataPack->m_pData, iOffset);
 		iItemDurabilityInSlots[i]	= CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
@@ -1700,7 +1700,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(DataPack* pDataPack, int& iOffset)
 	int iItemCountInInventorys[MAX_ITEM_INVENTORY]; memset(iItemCountInInventorys, -1, sizeof(iItemCountInInventorys));
 	int iItemDurabilityInInventorys[MAX_ITEM_INVENTORY]; memset(iItemDurabilityInInventorys, -1, sizeof(iItemDurabilityInInventorys));
 
-	for ( i = 0; i < MAX_ITEM_INVENTORY; i++ )				// 슬롯 갯수마큼..
+	for ( int i = 0; i < MAX_ITEM_INVENTORY; i++ )				// 슬롯 갯수마큼..
 	{
 		iItemIDInInventorys[i]			= CAPISocket::Parse_GetDword(pDataPack->m_pData, iOffset);
 		iItemDurabilityInInventorys[i]	= CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
@@ -1710,7 +1710,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(DataPack* pDataPack, int& iOffset)
 	m_pUIInventory->ReleaseItem();
 
 	std::string szResrcFN, szIconFN;
-	for ( i = 0; i < ITEM_SLOT_COUNT; i++ )				// 슬롯 갯수마큼..
+	for ( int i = 0; i < ITEM_SLOT_COUNT; i++ )				// 슬롯 갯수마큼..
 	{
 		if(0 == iItemIDInSlots[i]) continue;
 
@@ -1795,7 +1795,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(DataPack* pDataPack, int& iOffset)
 
 	// 인벤토리..
 	int iItemCount = 0;
-	for ( i = 0; i < MAX_ITEM_INVENTORY; i++ )				// 인벤토리 갯수만큼..	
+	for ( int i = 0; i < MAX_ITEM_INVENTORY; i++ )				// 인벤토리 갯수만큼..	
 	{
 		if(!iItemIDInInventorys[i]) continue;
 
@@ -2415,7 +2415,7 @@ bool CGameProcMain::MsgRecv_UserInAndRequest(DataPack* pDataPack, int& iOffset)
 		CAPISocket::MP_AddShort(&(byBuff[0]), iOffset, iNewUPCCount);		// 아이디 갯수..
 		
 		itID = m_SetUPCID.begin(); itIDEnd = m_SetUPCID.end();
-		for(i = 0; itID != itIDEnd; itID++, i++)
+		for(int i = 0; itID != itIDEnd; itID++, i++)
 		{
 			iID = *itID;
 			CAPISocket::MP_AddShort(&(byBuff[0]), iOffset, iID);			// 자세한 정보가 필요한 아이디들..
@@ -2767,7 +2767,7 @@ bool CGameProcMain::MsgRecv_NPCInAndRequest(DataPack* pDataPack, int& iOffset)
 		CAPISocket::MP_AddShort(&(byBuff[0]), iOffset, iNewNPCCount);		// 아이디 갯수..
 		
 		itID = m_SetNPCID.begin(); itIDEnd = m_SetNPCID.end();
-		for(i = 0; itID != itIDEnd; itID++, i++)
+		for(int i = 0; itID != itIDEnd; itID++, i++)
 		{
 			iID = *itID;
 			CAPISocket::MP_AddShort(&(byBuff[0]), iOffset, iID);			// 자세한 정보가 필요한 아이디들..
@@ -5976,7 +5976,6 @@ void CGameProcMain::MsgRecv_SkillPointInit(DataPack* pDataPack, int& iOffset)		/
 {
 	BYTE	bType		= CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);	
 	DWORD	dwGold		= CAPISocket::Parse_GetDword(pDataPack->m_pData, iOffset);	
-	int i;
 	char szBuf[256] = "";
 	std::string szMsg; 
 
@@ -5990,7 +5989,7 @@ void CGameProcMain::MsgRecv_SkillPointInit(DataPack* pDataPack, int& iOffset)		/
 
 		case 0x01:	// 성공..
 			m_pUISkillTreeDlg->m_iSkillInfo[0] = CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);
-			for ( i = 1; i < 9; i++ )
+			for ( int i = 1; i < 9; i++ )
 				m_pUISkillTreeDlg->m_iSkillInfo[i] = 0;
 			m_pUISkillTreeDlg->InitIconUpdate();
 
@@ -6579,7 +6578,7 @@ void CGameProcMain::MsgRecv_Knights_GradeChangeAll(DataPack* pDataPack, int& iOf
 		int iIDTmp = pUPC->m_InfoExt.iKnightsID;
 		if(iIDTmp <= 0) continue;
 
-		for(i = 0; i < iCount; i++)
+		for(int i = 0; i < iCount; i++)
 		{
 			if(iIDs[i] == iIDTmp)
 			{

--- a/src/game/GrassMng.cpp
+++ b/src/game/GrassMng.cpp
@@ -336,7 +336,7 @@ void CGrassMng::ChkThisZoneUseGrass(int nGrassUseOrder)
 //		for(int nGrassCount=0;nGrassCount<iSize;nGrassCount++)
 		while(nGrassCount<iSize)
 		{
-			for(i=0;i<GrassInputCount && nGrassCount<iSize;i++,nGrassCount++,it++)
+			for(int i=0;i<GrassInputCount && nGrassCount<iSize;i++,nGrassCount++,it++)
 			{
 				pGrass = *it;
 				pGrass->TexSelectNum(InputGrass[i],InputGrassOrg[i]);

--- a/src/game/ItemRepairMgr.cpp
+++ b/src/game/ItemRepairMgr.cpp
@@ -46,8 +46,8 @@ void CItemRepairMgr::Tick()
 	POINT ptCur			= CGameProcedure::s_pLocalInput->MouseGetPos();
 
 	// 위치를 구해서 
-	int i;	int iArm = 0x00; int iOrder = -1; __IconItemSkill* spItem = NULL;
-	for (i = 0; i < ITEM_SLOT_COUNT; i++)
+	int iArm = 0x00; int iOrder = -1; __IconItemSkill* spItem = NULL;
+	for (int i = 0; i < ITEM_SLOT_COUNT; i++)
 	{
 		if (spItem) break;
 		if (pInv->m_pMySlot[i])
@@ -63,7 +63,7 @@ void CItemRepairMgr::Tick()
 
 	if (!spItem)
 	{
-		for (i = 0; i < MAX_ITEM_INVENTORY; i++)
+		for (int i = 0; i < MAX_ITEM_INVENTORY; i++)
 		{
 			if (spItem) break;
 			if (pInv->m_pMyInvWnd[i])

--- a/src/game/KnightOnLine.vcxproj
+++ b/src/game/KnightOnLine.vcxproj
@@ -65,7 +65,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -101,7 +100,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/game/LightMgr.cpp
+++ b/src/game/LightMgr.cpp
@@ -74,7 +74,6 @@ void CLightMgr::Release()
 
 void CLightMgr::Tick()
 {
-	int i;
 	//거리에 따라 추려내고...
 	int NumSlotEmpty = 0;
 	float LimitLeft, LimitRight, LimitUp, LimitDown;
@@ -84,7 +83,7 @@ void CLightMgr::Tick()
 	LimitDown = CN3Base::s_CameraData.vEye.z - LIGHT_VALIDRANGE;
 
 	__Vector3 vPosTmp;
-	for(i=LGT_ADDITIONAL0;i<LGT_MAX;i++)
+	for(int i=LGT_ADDITIONAL0;i<LGT_MAX;i++)
 	{
 		if(!m_pActiveLight[i])
 		{
@@ -113,7 +112,7 @@ void CLightMgr::Tick()
 		vPosTmp = pLgt->Pos();
 		if(vPosTmp.x > LimitLeft && vPosTmp.x < LimitRight && vPosTmp.z > LimitDown && vPosTmp.z < LimitUp)
 		{
-			for(i=LGT_ADDITIONAL0;i<LGT_MAX;i++)
+			for(int i=LGT_ADDITIONAL0;i<LGT_MAX;i++)
 			{
 				if(!m_pActiveLight[i])
 				{
@@ -130,7 +129,7 @@ void CLightMgr::Tick()
 	}
 
 	//tick돌려라..
-	for(i=0;i<LGT_MAX;i++)
+	for(int i=0;i<LGT_MAX;i++)
 	{
 		if(m_pActiveLight[i])
 		{

--- a/src/game/MachineBase.cpp
+++ b/src/game/MachineBase.cpp
@@ -127,8 +127,7 @@ void CMachineBase::Tick(float fFrm)
 			if (m_fDirRadian > (2 * D3DX_PI)) m_fDirRadian -= (2 * D3DX_PI);
 		}
 		// 바퀴 회전각 계산.
-		int i;
-		for (i=0; i<NUM_WHEEL; ++i)
+		for (int i=0; i<NUM_WHEEL; ++i)
 		{
 			m_Wheel[i].fRadian += fAddRadian*m_Wheel[i].fRotateRatio;
 		}
@@ -155,8 +154,7 @@ void CMachineBase::Tick(float fFrm)
 			m_vPos = vPos;
 
 			// 바퀴 회전각 계산.
-			int i;
-			for (i=0; i<NUM_WHEEL; ++i)
+			for (int i=0; i<NUM_WHEEL; ++i)
 			{
 				m_Wheel[i].fRadian -= (fDistance/m_Wheel[i].fRadius);
 			}
@@ -164,8 +162,7 @@ void CMachineBase::Tick(float fFrm)
 	}
 
 	// 바퀴 회전각 0~2pi 사이로 조정
-	int i;
-	for (i=0; i<NUM_WHEEL; ++i)
+	for (int i=0; i<NUM_WHEEL; ++i)
 	{
 		if (m_Wheel[i].fRadian > D3DX_PI*2)	m_Wheel[i].fRadian -= (D3DX_PI*2);
 		else if (m_Wheel[i].fRadian < 0.0f)	m_Wheel[i].fRadian += (D3DX_PI*2);
@@ -224,8 +221,7 @@ void CMachineBase::LoadMachine(FILE* stream)
 	ZeroMemory(m_bSkipCalcPartMtx, sizeof(m_bSkipCalcPartMtx[0])*iPartCount);
 
 	// 각각의 바퀴 CN3SPart 포인터 찾기
-	int i;
-	for (i=0; i<NUM_WHEEL; ++i)
+	for (int i=0; i<NUM_WHEEL; ++i)
 	{
 		m_Wheel[i].pPart = GetPartByPMeshName(szWheel[i]);
 		__ASSERT(m_Wheel[i].pPart, "Machine의 바퀴 파트가 NULL입니다.");
@@ -236,7 +232,7 @@ void CMachineBase::LoadMachine(FILE* stream)
 	}
 
 	// machine이 1.0f(rad)회전할때 바퀴가 돌아가는 각도(rad) 정도 계산하기
-	for (i=0; i<NUM_WHEEL; ++i)
+	for (int i=0; i<NUM_WHEEL; ++i)
 	{
 		if (i == WHEEL_FL || i == WHEEL_BL)
 			m_Wheel[i].fRotateRatio = m_Wheel[i].pPart->m_vPivot.Magnitude() / m_Wheel[i].fRadius;

--- a/src/game/N3EffectWave2.cpp
+++ b/src/game/N3EffectWave2.cpp
@@ -107,7 +107,6 @@ bool CN3EffectWave2::Load(HANDLE hFile)
 		ptmpPondMesh->m_iIC = iIC;		///
 		ptmpPondMesh->m_wpIndex = new WORD [iVC*6];		///
 
-		int j,k;
 		int iWidth = iWidthVertex,iHeight = iVC/iWidthVertex;
 		int x=0,y=iWidth;
 		WORD* indexPtr = ptmpPondMesh->m_wpIndex;	//	삼각형을 부를 위치 설정
@@ -117,9 +116,9 @@ bool CN3EffectWave2::Load(HANDLE hFile)
 		float StX,EnX,StZ,EnZ;
 		StX = ptVtx[0].x,EnX = ptVtx[iWidth].x;
 		StZ = ptVtx[0].z,EnZ = ptVtx[iHeight].z;
-		for (j=0; j<iHeight; j++)
+		for (int j=0; j<iHeight; j++)
 		{
-			for (k=0; k<iWidth; k++)
+			for (int k=0; k<iWidth; k++)
 			{
 				//	삼각형을 부를 위치 설정
 				indexPtr[0] = x;

--- a/src/game/N3Terrain.cpp
+++ b/src/game/N3Terrain.cpp
@@ -97,7 +97,7 @@ CN3Terrain::CN3Terrain()
 
 	m_bAvailableTile = true;
 
-	for(i=0;i<3;i++)
+	for(int i=0;i<3;i++)
 		for(int j=0;j<3;j++) m_LightMapPatch[i][j].clear();
 }
 
@@ -114,13 +114,11 @@ CN3Terrain::~CN3Terrain()
 //
 void CN3Terrain::MakeDistanceTable()
 {
-	int x,z;
-	double dist;
-	for(x=0;x<DISTANCE_TABLE_SIZE;x++)
+	for(int x=0;x<DISTANCE_TABLE_SIZE;x++)
 	{
-		for(z=0;z<DISTANCE_TABLE_SIZE;z++)
+		for(int z=0;z<DISTANCE_TABLE_SIZE;z++)
 		{
-			dist = sqrt( (double)((x*x) + (z*z)) ) + 0.6;
+			double dist = sqrt( (double)((x*x) + (z*z)) ) + 0.6;
 			m_iDistanceTable[x][z] = (int)dist;
 		}
 	}
@@ -132,8 +130,6 @@ void CN3Terrain::MakeDistanceTable()
 //
 void CN3Terrain::Release()
 {	
-	int x;
-
 	if(m_pGrassAttr)
 	{
 		//free(m_pGrassAttr);
@@ -149,7 +145,7 @@ void CN3Terrain::Release()
 	}
 
 //	{
-//		for(x=0;x<m_ti_MapSize;x++)
+//		for(int x=0;x<m_ti_MapSize;x++)
 //		{
 //			if(m_ppGrassAttr[x])
 //			{
@@ -176,7 +172,7 @@ void CN3Terrain::Release()
 
 	if(m_pTileTex)
 	{
-//		for(x=0;x<m_NumTileTex;x++)
+//		for(int x=0;x<m_NumTileTex;x++)
 //			m_pTileTex[x].Release();
 		delete[] m_pTileTex;
 		m_pTileTex = NULL;
@@ -184,9 +180,9 @@ void CN3Terrain::Release()
 	
 	if(m_ppColorMapTex)
 	{
-		for(x=0;x<m_iNumColorMap;x++)
+		for(int x=0;x<m_iNumColorMap;x++)
 		{
-//			for(z=0;z<m_iNumColorMap;z++)
+//			for(int z=0;z<m_iNumColorMap;z++)
 //			{
 //				m_ppColorMapTex[x][z].Release();
 //			}
@@ -199,9 +195,9 @@ void CN3Terrain::Release()
 
 	if(m_ppPatch)
 	{
-		for(x=0;x<m_iNumPatch;x++)
+		for(int x=0;x<m_iNumPatch;x++)
 		{
-//			for(z=0;z<m_iNumPatch;z++)
+//			for(int z=0;z<m_iNumPatch;z++)
 //			{
 //				m_ppPatch[x][z].Release();
 //			}
@@ -227,7 +223,7 @@ void CN3Terrain::Release()
 
 	if(m_ppPatchRadius)
 	{
-		for(x=0;x<m_pat_MapSize;x++)
+		for(int x=0;x<m_pat_MapSize;x++)
 		{
 			delete[] m_ppPatchRadius[x];
 			m_ppPatchRadius[x] = NULL;
@@ -238,7 +234,7 @@ void CN3Terrain::Release()
 
 	if(m_ppPatchMiddleY)
 	{
-		for(x=0;x<m_pat_MapSize;x++)
+		for(int x=0;x<m_pat_MapSize;x++)
 		{
 			delete[] m_ppPatchMiddleY[x];
 			m_ppPatchMiddleY[x] = NULL;
@@ -247,10 +243,9 @@ void CN3Terrain::Release()
 		m_ppPatchMiddleY = NULL;
 	}
 
-	int z;
-	for(x=0;x<3;x++)
+	for(int x=0;x<3;x++)
 	{
-		for(z=0;z<3;z++)
+		for(int z=0;z<3;z++)
 		{
 			stlMap_N3TexIt itBegin = m_LightMapPatch[x][z].begin();
 			stlMap_N3TexIt itEnd = m_LightMapPatch[x][z].end();
@@ -294,16 +289,14 @@ void CN3Terrain::Init()
 	
 	m_iNumPatch = (m_pat_Center2Side<<1) + 1;
 	
-	int x;
 	m_ppPatch = new CN3TerrainPatch* [m_iNumPatch];
-	for(x=0;x<m_iNumPatch;x++)
+	for(int x=0;x<m_iNumPatch;x++)
 	{
 		m_ppPatch[x] = new CN3TerrainPatch [m_iNumPatch];		
 	}
-	int z;
-	for(x=0;x<m_iNumPatch;x++)
+	for(int x=0;x<m_iNumPatch;x++)
 	{
-		for(z=0;z<m_iNumPatch;z++)
+		for(int z=0;z<m_iNumPatch;z++)
 		{
 			m_ppPatch[x][z].Init(this);
 		}
@@ -418,8 +411,6 @@ bool CN3Terrain::Load(HANDLE hFile)
 	ReadFile(hFile, &(m_ti_MapSize), sizeof(int), &dwRWC, NULL);
 	m_pat_MapSize = (m_ti_MapSize-1) / PATCH_TILE_SIZE;
 
-	int x, z;
-
 	//m_pMapData = (LPMAPDATA)malloc(sizeof(MAPDATA)*m_ti_MapSize*m_ti_MapSize);
 	m_pMapData = (LPMAPDATA)GlobalAlloc(GMEM_FIXED, sizeof(MAPDATA)*m_ti_MapSize*m_ti_MapSize);
 	if(m_pMapData==NULL) CLogWriter::Write("Terrain Error : MapData Memory Allocation Failed..-.-");
@@ -437,7 +428,7 @@ bool CN3Terrain::Load(HANDLE hFile)
 
 	m_ppPatchRadius = new float* [m_pat_MapSize];
 	m_ppPatchMiddleY = new float* [m_pat_MapSize];
-	for(x=0;x<m_pat_MapSize;x++)
+	for(int x=0;x<m_pat_MapSize;x++)
 	{
 		m_ppPatchMiddleY[x] = new float [m_pat_MapSize];
 		m_ppPatchRadius[x] = new float [m_pat_MapSize];
@@ -446,9 +437,9 @@ bool CN3Terrain::Load(HANDLE hFile)
 	if(pUILoading) pUILoading->Render("Loading Terrain Patch Data...", 0);
 
 	char szLoadingBuff[128];
-	for(x=0; x<m_pat_MapSize; x++)
+	for(int x=0; x<m_pat_MapSize; x++)
 	{
-		for(z=0; z<m_pat_MapSize; z++)
+		for(int z=0; z<m_pat_MapSize; z++)
 		{
 			ReadFile(hFile, &(m_ppPatchMiddleY[x][z]), sizeof(float), &dwRWC, NULL);
 			ReadFile(hFile, &(m_ppPatchRadius[x][z]), sizeof(float), &dwRWC, NULL);
@@ -461,7 +452,7 @@ bool CN3Terrain::Load(HANDLE hFile)
 	}
 
 //	m_ppGrassAttr = new unsigned char* [m_ti_MapSize];
-//	for(x=0; x<m_ti_MapSize; x++)
+//	for(int x=0; x<m_ti_MapSize; x++)
 //	{
 //		m_ppGrassAttr[x] = new unsigned char[m_ti_MapSize];
 //		ReadFile(hFile, m_ppGrassAttr[x], sizeof(unsigned char)*m_ti_MapSize, &dwRWC, NULL);
@@ -530,12 +521,11 @@ void CN3Terrain::SetNormals()
 {
 	return;
 /*
-	int x,z;
 	__Vector3 vNormalTmp(0.0f, 0.0f, 0.0f);
 	__Vector3 V1, V2;
-	for(x=0;x<m_ti_MapSize;x++)
+	for(int x=0;x<m_ti_MapSize;x++)
 	{
-		for(z=0;z<m_ti_MapSize;z++)
+		for(int z=0;z<m_ti_MapSize;z++)
 		{
 			if( x==0 || z==0 || x==(m_ti_MapSize-1) || z==(m_ti_MapSize-1) )
 			{
@@ -684,7 +674,7 @@ void CN3Terrain::LoadTileInfo(HANDLE hFile)
 	short SrcIdx, TileIdx;
 	HANDLE hTTGFile;
 	char szLoadingBuff[128];
-	for(i=0;i<m_NumTileTex;i++)
+	for(int i=0;i<m_NumTileTex;i++)
 	{
 		ReadFile(hFile, &SrcIdx, sizeof(short), &dwRWC, NULL);
 		ReadFile(hFile, &TileIdx, sizeof(short), &dwRWC, NULL);
@@ -708,7 +698,7 @@ void CN3Terrain::LoadTileInfo(HANDLE hFile)
 		CloseHandle(hTTGFile);
 	}
 
-	for(i=0;i<NumTileTexSrc;i++)
+	for(int i=0;i<NumTileTexSrc;i++)
 	{
 		delete[] SrcName[i];
 		SrcName[i] = NULL;
@@ -730,13 +720,11 @@ bool CN3Terrain::SetLODLevel(int level)
 
 	if(m_iLodLevel<2) m_iLodLevel = 2; 
 
-	int x,z;
-	int dist;
-	for(x=0;x<m_iNumPatch;x++)
+	for(int x=0;x<m_iNumPatch;x++)
 	{
-		for(z=0;z<m_iNumPatch;z++)
+		for(int z=0;z<m_iNumPatch;z++)
 		{
-			dist = m_iDistanceTable[T_Abs(m_pat_Center2Side-x)][T_Abs(m_pat_Center2Side-z)];
+			int dist = m_iDistanceTable[T_Abs(m_pat_Center2Side-x)][T_Abs(m_pat_Center2Side-z)];
 			if(dist <= m_iLodLevel) m_ppPatch[x][z].SetLevel(1);
 			else if(dist <= m_iLodLevel+3) m_ppPatch[x][z].SetLevel(2);
 			else m_ppPatch[x][z].SetLevel(3);
@@ -834,12 +822,11 @@ void CN3Terrain::Tick()
 
 	bool bChangeBound = CheckBound();
 
-	int x,z;
 	if( (bMovePatch) || (bChangeBound) || ChangeLOD)
 	{
-		for(x=m_pat_BoundRect.left; x<=m_pat_BoundRect.right; x++)
+		for(int x=m_pat_BoundRect.left; x<=m_pat_BoundRect.right; x++)
 		{
-			for(z=m_pat_BoundRect.top; z<=m_pat_BoundRect.bottom; z++)
+			for(int z=m_pat_BoundRect.top; z<=m_pat_BoundRect.bottom; z++)
 			{
 				if(x<0 || z<0) continue;
 				m_ppPatch[x][z].Tick();
@@ -875,23 +862,20 @@ bool CN3Terrain::CheckMovePatch()
 //
 void CN3Terrain::DispositionPatch()
 {
-	int x,z;
-	int px,pz;
-	int cx,cz;
-	for(x=0; x<m_iNumPatch; x++)
+	for(int x=0; x<m_iNumPatch; x++)
 	{
-		for(z=0; z<m_iNumPatch; z++)
+		for(int z=0; z<m_iNumPatch; z++)
 		{
-			px = m_pat_LBPos.x+x;
-			pz = m_pat_LBPos.y+z;
+			int px = m_pat_LBPos.x+x;
+			int pz = m_pat_LBPos.y+z;
 
 			if(px<0 || pz<0 || px >= m_pat_MapSize || pz >= m_pat_MapSize) continue;
 
 			m_ppPatch[x][z].m_ti_LBPoint.x = px * PATCH_TILE_SIZE;
 			m_ppPatch[x][z].m_ti_LBPoint.y = pz * PATCH_TILE_SIZE;
 
-			cx = px*PATCH_PIXEL_SIZE/COLORMAPTEX_SIZE;
-			cz = pz*PATCH_PIXEL_SIZE/COLORMAPTEX_SIZE;
+			int cx = px*PATCH_PIXEL_SIZE/COLORMAPTEX_SIZE;
+			int cz = pz*PATCH_PIXEL_SIZE/COLORMAPTEX_SIZE;
 			if(cx < 0 || cz < 0 || cx >= m_iNumColorMap || cz >= m_iNumColorMap) m_ppPatch[x][z].m_pRefColorTex = NULL;
 			else m_ppPatch[x][z].m_pRefColorTex = &(m_ppColorMapTex[cx][cz]);
 		}
@@ -936,7 +920,7 @@ void CN3Terrain::DispositionPatch()
 //
 void CN3Terrain::SetLightMap(int dir)
 {
-	return;
+	return; // TODO: I suppose this needs to be reworked.
 	__TABLE_ZONE* pZoneData = CGameBase::s_pTbl_Zones->Find(CGameBase::s_pPlayer->m_InfoExt.iZoneCur);
 	if(!pZoneData) return;
 
@@ -1147,17 +1131,16 @@ void CN3Terrain::SetLightMapPatch(int x, int z, HANDLE hFile, int* pAddr)
 	int TexCount;
 	ReadFile(hFile, &TexCount, sizeof(int), &dwRWC, NULL);
 	
-	int tx, tz;
-	int rtx, rtz;
 	for(int i=0;i<TexCount;i++)
 	{
+		int tx, tz;
 		ReadFile(hFile, &tx, sizeof(int), &dwRWC, NULL);
 		ReadFile(hFile, &tz, sizeof(int), &dwRWC, NULL);
 
 		CN3Texture* pTex = new CN3Texture;
 		pTex->Load(hFile);
-		rtx = px*PATCH_TILE_SIZE + tx;
-		rtz = pz*PATCH_TILE_SIZE + tz;
+		int rtx = px*PATCH_TILE_SIZE + tx;
+		int rtz = pz*PATCH_TILE_SIZE + tz;
 
 		DWORD key = rtx*10000+rtz;
 		m_LightMapPatch[x][z].insert(stlMap_N3TexValue(key,pTex));
@@ -1170,9 +1153,8 @@ void CN3Terrain::SetLightMapPatch(int x, int z, HANDLE hFile, int* pAddr)
 //
 CN3Texture* CN3Terrain::GetLightMap(int tx, int tz)
 {
-	int px, pz;
-	px = tx / PATCH_TILE_SIZE;
-	pz = tz / PATCH_TILE_SIZE;
+	int px = tx / PATCH_TILE_SIZE;
+	int pz = tz / PATCH_TILE_SIZE;
 
 	px -= (m_pat_CenterPos.x-1);
 	pz -= (m_pat_CenterPos.y-1);
@@ -1217,7 +1199,7 @@ bool CN3Terrain::CheckBound()
 		vFPs[i] = vFPs[i] * CN3Base::s_CameraData.mtxViewInverse;
 
 	
-	for(i=0;i<4;i++)
+	for(int i=0;i<4;i++)
 	{
 		POINT FarPoint;
 		FarPoint.x = Real2Patch(vFPs[i].x);
@@ -1260,20 +1242,18 @@ bool CN3Terrain::CheckRenderablePatch()
 {
 	bool bChange = false;
 	__Vector3 CenterPoint;
-	int px, pz;
-	int x,z;
 	BOOL PrevState;
-	for(x=m_pat_BoundRect.left; x<=m_pat_BoundRect.right; x++)
+	for(int x=m_pat_BoundRect.left; x<=m_pat_BoundRect.right; x++)
 	{
-		for(z=m_pat_BoundRect.top; z<=m_pat_BoundRect.bottom; z++)
+		for(int z=m_pat_BoundRect.top; z<=m_pat_BoundRect.bottom; z++)
 		{
 			if(x<0 || z<0) continue;
 
 			PrevState = m_ppPatch[x][z].m_bIsRender;
 			m_ppPatch[x][z].m_bIsRender = TRUE;
 
-			px = m_pat_LBPos.x + x;
-			pz = m_pat_LBPos.y + z;
+			int px = m_pat_LBPos.x + x;
+			int pz = m_pat_LBPos.y + z;
 
 			if(px<0 || pz<0 || px >= m_pat_MapSize || pz >= m_pat_MapSize)
 			{
@@ -1343,10 +1323,9 @@ void CN3Terrain::Render()
 	hr = s_lpD3DDev->SetSamplerState( 1, D3DSAMP_ADDRESSU,  D3DTADDRESS_MIRROR );
 	hr = s_lpD3DDev->SetSamplerState( 1, D3DSAMP_ADDRESSV,  D3DTADDRESS_MIRROR );
 
-	int x,z;
-	for(x=m_pat_BoundRect.left; x<=m_pat_BoundRect.right; x++)
+	for(int x=m_pat_BoundRect.left; x<=m_pat_BoundRect.right; x++)
 	{
-		for(z=m_pat_BoundRect.top; z<=m_pat_BoundRect.bottom; z++)
+		for(int z=m_pat_BoundRect.top; z<=m_pat_BoundRect.bottom; z++)
 		{
 			if(x<0 || z<0) continue;
 			m_ppPatch[x][z].Render();
@@ -1401,16 +1380,14 @@ inline int CN3Terrain::Log2(int x)
 //
 float CN3Terrain::GetHeight(float x, float z)
 {
-	int ix, iz;
-	ix = ((int)x) / TILE_SIZE;
-	iz = ((int)z) / TILE_SIZE;
+	int ix = ((int)x) / TILE_SIZE;
+	int iz = ((int)z) / TILE_SIZE;
 
 	if(ix<0 || ix>(m_ti_MapSize-2)) return -FLT_MAX;
 	if(iz<0 || iz>(m_ti_MapSize-2)) return -FLT_MAX;
 
-	float dX, dZ;
-	dX = (x - (ix*TILE_SIZE)) / TILE_SIZE;
-	dZ = (z - (iz*TILE_SIZE)) / TILE_SIZE;
+	float dX = (x - (ix*TILE_SIZE)) / TILE_SIZE;
+	float dZ = (z - (iz*TILE_SIZE)) / TILE_SIZE;
 
 	float y;
 	float h1, h2, h3, h12, h13;
@@ -1488,13 +1465,11 @@ void CN3Terrain::GetNormal(float x, float z, __Vector3& vNormal)
 		return;
 	}
 
-	int ix, iz;
-	ix = ((int)x) / TILE_SIZE;
-	iz = ((int)z) / TILE_SIZE;
+	int ix = ((int)x) / TILE_SIZE;
+	int iz = ((int)z) / TILE_SIZE;
 
-	float dX, dZ;
-	dX = (x - ix*TILE_SIZE)/TILE_SIZE;
-	dZ = (z - iz*TILE_SIZE)/TILE_SIZE;
+	float dX = (x - ix*TILE_SIZE)/TILE_SIZE;
+	float dZ = (z - iz*TILE_SIZE)/TILE_SIZE;
 
 	__Vector3 v1,v2;
 	vNormal.Set(0,1,0);
@@ -2104,7 +2079,7 @@ bool CN3Terrain::LoadColorMap(const std::string& szFN)
 	}
 
 	char szBuff[128];
-	for(x=0;x<m_iNumColorMap;x++)
+	for(int x=0;x<m_iNumColorMap;x++)
 	{
 		for(int z=0;z<m_iNumColorMap;z++)
 		{
@@ -2131,9 +2106,8 @@ CN3Texture* CN3Terrain::GetTileTex(int x, int z)
 
 bool CN3Terrain::GetTileTexInfo(float x, float z, TERRAINTILETEXINFO& TexInfo1, TERRAINTILETEXINFO& TexInfo2)
 {
-	int tx, tz;
-	tx = x / TILE_SIZE;
-	tz = z / TILE_SIZE;
+	int tx = x / TILE_SIZE;
+	int tz = z / TILE_SIZE;
 
 	if(tx<0 || tx>=m_ti_MapSize || tz<0 || tz>=m_ti_MapSize) return false;
 

--- a/src/game/N3TerrainPatch.cpp
+++ b/src/game/N3TerrainPatch.cpp
@@ -140,7 +140,7 @@ void CN3TerrainPatch::Init(CN3Terrain* pTerrain)
 	m_pVB = NULL;
 	m_pRefColorTex = NULL;
 
-	for(i=0;i<2;i++) 
+	for(int i=0;i<2;i++) 
 	{
 		m_pTileTexIndx[i] = new int [PATCH_TILE_SIZE*PATCH_TILE_SIZE];
 		memset(m_pTileTexIndx[i], -1, sizeof(int)*PATCH_TILE_SIZE*PATCH_TILE_SIZE);
@@ -899,7 +899,7 @@ void CN3TerrainPatch::Render()
 		hr = s_lpD3DDev->SetRenderState( D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
 		hr = s_lpD3DDev->SetRenderState( D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
 		
-		for(i=0;i<m_NumLightMapTex;i++)
+		for(int i=0;i<m_NumLightMapTex;i++)
 		{
 			s_lpD3DDev->SetTexture( 0, m_pRefLightMapTex[i]->Get());
 			hr = s_lpD3DDev->DrawPrimitive( D3DPT_TRIANGLEFAN, (i<<2), 2);

--- a/src/game/PlayerBase.cpp
+++ b/src/game/PlayerBase.cpp
@@ -2173,7 +2173,7 @@ void CPlayerBase::RenderShadow(float fAngle)
 	for( int i = 0; i < SHADOW_SIZE; i++ )
 		m_bitset[i].Resize(SHADOW_SIZE);
 
-	for ( i = 0; i < 4; i++ )
+	for ( int i = 0; i < 4; i++ )
 	{
 		m_vTVertex[i]  = m_pvVertex[i];	
 		m_vTVertex[i] *= mV;
@@ -2186,7 +2186,7 @@ void CPlayerBase::RenderShadow(float fAngle)
 	if (fScale > 6.6f)
 	{
 		m_fShaScale = 2.2f;
-		for ( i = 0; i < 4; i++ )
+		for ( int i = 0; i < 4; i++ )
 		{
 			m_vTVertex[i]  = m_pvVertex[i];	
 			m_vTVertex[i] *= m_fShaScale;
@@ -2195,7 +2195,7 @@ void CPlayerBase::RenderShadow(float fAngle)
 	}
 	else
 	{
-		for ( i = 0; i < 4; i++ )
+		for ( int i = 0; i < 4; i++ )
 		{
 			m_vTVertex[i]  = m_pvVertex[i];	
 			m_vTVertex[i] *= mtPos;
@@ -2226,13 +2226,13 @@ void CPlayerBase::RenderShadow(float fAngle)
 	__Vector3 vLP; vLP.Set(-zVal, 0.0f, 0.0f );	vLP *= mtxRZ;	vLP.Normalize();
 
 	int iPC = m_Chr.PartCount();
-	for( i = 0; i < iPC; i++)
+	for( int i = 0; i < iPC; i++)
 	{
 		CalcPart(m_Chr.Part(i), iLODTemp, vLP);
 	}
 
 	iPC = m_Chr.PlugCount();
-	for(i = 0; i < iPC; i++)
+	for(int i = 0; i < iPC; i++)
 	{
 		CalcPlug(m_Chr.Plug(i), m_Chr.MatrixGet(m_Chr.Plug(i)->m_nJointIndex), mVvar, vLP);
 	}
@@ -2240,7 +2240,7 @@ void CPlayerBase::RenderShadow(float fAngle)
 	// 렌더링하기 전에 스케일을 줄인다..
 	if (fScale > 6.6f)
 	{
-		for ( i = 0; i < 4; i++ )
+		for ( int i = 0; i < 4; i++ )
 		{
 			m_vTVertex[i]  = m_pvVertex[i];	
 			m_vTVertex[i] *= 0.82f;	
@@ -2250,7 +2250,7 @@ void CPlayerBase::RenderShadow(float fAngle)
 	}
 	else
 	{
-		for ( i = 0; i < 4; i++ )
+		for ( int i = 0; i < 4; i++ )
 		{
 			m_vTVertex[i]  = m_pvVertex[i];	
 			m_vTVertex[i] *= 0.5f;	
@@ -2267,7 +2267,7 @@ void CPlayerBase::RenderShadow(float fAngle)
 	LPWORD pDst16 = (LPWORD)LR.pBits;
 	WORD dwColor = SHADOW_COLOR;
 	dwColor = dwColor << 12;
-	for( i = 0; i < SHADOW_SIZE; i++ )
+	for( int i = 0; i < SHADOW_SIZE; i++ )
 	{
 		for(int j = 0; j < SHADOW_SIZE; j++ )
 		{

--- a/src/game/PlayerMySelf.cpp
+++ b/src/game/PlayerMySelf.cpp
@@ -428,7 +428,7 @@ void CPlayerMySelf::InventoryChrRender(const RECT& Rect)
 	if (dwUseLighting) CN3Base::s_lpD3DDev->SetRenderState( D3DRS_LIGHTING, TRUE );
 	if (dwUsefog) CN3Base::s_lpD3DDev->SetRenderState( D3DRS_FOGENABLE, FALSE );
 	// set render states
-	for ( i = 1; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, FALSE);
+	for ( int i = 1; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, FALSE);
 	CN3Base::s_lpD3DDev->LightEnable(0, TRUE);
 
 	D3DLIGHT9 lgt0;
@@ -501,7 +501,7 @@ void CPlayerMySelf::InventoryChrRender(const RECT& Rect)
 
 	CN3Base::s_lpD3DDev->SetRenderState( D3DRS_LIGHTING, dwUseLighting );
 	CN3Base::s_lpD3DDev->SetRenderState( D3DRS_FOGENABLE , dwUsefog );
-	for ( i = 0; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, bLight[i]);
+	for ( int i = 0; i < 8; i++ )	CN3Base::s_lpD3DDev->LightEnable(i, bLight[i]);
 */
 	// 아래로 dino수정
 	// backup render state
@@ -515,7 +515,7 @@ void CPlayerMySelf::InventoryChrRender(const RECT& Rect)
 
 	// set render state
 	if (TRUE != dwLighting) s_lpD3DDev->SetRenderState( D3DRS_LIGHTING, TRUE );
-	for ( i = 1; i < 8; ++i )	s_lpD3DDev->LightEnable(i, FALSE);
+	for ( int i = 1; i < 8; ++i )	s_lpD3DDev->LightEnable(i, FALSE);
 	s_lpD3DDev->LightEnable(0, TRUE);
 
 	// 0번 light 설정
@@ -539,7 +539,7 @@ void CPlayerMySelf::InventoryChrRender(const RECT& Rect)
 
 	// restore
 	if (TRUE != dwLighting) s_lpD3DDev->SetRenderState( D3DRS_LIGHTING, dwLighting );
-	for (i = 0; i < 8; ++i )	s_lpD3DDev->LightEnable(i, bLight[i]);
+	for (int i = 0; i < 8; ++i )	s_lpD3DDev->LightEnable(i, bLight[i]);
 	s_lpD3DDev->SetLight(0, &BackupLight0);
 }
 

--- a/src/game/PlayerOtherMgr.cpp
+++ b/src/game/PlayerOtherMgr.cpp
@@ -650,7 +650,7 @@ CPlayerNPC* CPlayerOtherMgr::PickAllPrecisely(int ixScreen, int iyScreen, int &i
 		}
 	}
 
-	for(i = 0; i < iBufCnt; i++)
+	for(int i = 0; i < iBufCnt; i++)
 	{
 		pNPC = NUPCBufs[i];
 		if(pNPC->LODLevel() < 0 || pNPC->LODLevel() >= MAX_CHR_LOD) continue; // Level Of Detail 이 없는건 지나간다.

--- a/src/game/PortalVolume.cpp
+++ b/src/game/PortalVolume.cpp
@@ -303,7 +303,7 @@ bool CPortalVolume::Load(HANDLE hFile)
 	// 링크된 Shape 갯수 로드..
 	int iCount = 0;
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
-	for (i = 0; i < iCount; i++)
+	for (int i = 0; i < iCount; i++)
 	{
 		ShapeInfo*	pSI = new ShapeInfo;
 		ReadFile(hFile, &pSI->m_iID, sizeof(int), &dwNum, NULL);
@@ -331,7 +331,7 @@ bool CPortalVolume::Load(HANDLE hFile)
 	IDAndPriority IDAP;
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
 
-	for( i = 0; i < iCount; i++ )
+	for( int i = 0; i < iCount; i++ )
 	{
 		ReadFile(hFile, &IDAP.m_iID, sizeof(int), &dwNum, NULL);
 		ReadFile(hFile, &IDAP.m_iPriority, sizeof(int), &dwNum, NULL);
@@ -342,7 +342,7 @@ bool CPortalVolume::Load(HANDLE hFile)
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
 
 	int iSize_2 = 0, iSize_3 = 0;
-	for( i = 0; i < iCount; i++ )
+	for( int i = 0; i < iCount; i++ )
 	{
 		ShapePart* pSP = new ShapePart;
 		ReadFile(hFile, &pSP->m_iID, sizeof(int), &dwNum, NULL);
@@ -369,7 +369,7 @@ bool CPortalVolume::Load(HANDLE hFile)
 
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
 
-	for( i = 0; i < iCount; i++ )
+	for( int i = 0; i < iCount; i++ )
 	{
 		__ColIndex* pCI = new __ColIndex;
 		ReadFile(hFile, &pCI->m_iID, sizeof(int), &dwNum, NULL);		

--- a/src/game/PvsMgr.cpp
+++ b/src/game/PvsMgr.cpp
@@ -183,7 +183,7 @@ bool CPvsMgr::Load(HANDLE hFile)
 	CPortalVolume* pVol = NULL, *pVolTo = NULL;
 	int iID;
 
-	for( i = 0; i < iCount; i++ )
+	for( int i = 0; i < iCount; i++ )
 	{
 		ReadFile(hFile, &iID, sizeof(int), &dwNum, NULL);
 		pVol = new CPortalVolume;

--- a/src/game/SubProcPerTrade.cpp
+++ b/src/game/SubProcPerTrade.cpp
@@ -868,9 +868,10 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int i
 			return;
 		}
 
+		int i;
 		if( (pItem->byContable == UIITEM_TYPE_COUNTABLE) || (pItem->byContable == UIITEM_TYPE_COUNTABLE_SMALL) )
 		{
-			for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )
+			for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )
 			{
 				if( (m_pUIPerTradeDlg->m_pPerTradeOther[i]) && (m_pUIPerTradeDlg->m_pPerTradeOther[i]->pItemBasic->dwID == pItem->dwID) )
 				{
@@ -941,7 +942,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int i
 		}
 		else
 		{
-			for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )
+			for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )
 			{
 				if (m_pUIPerTradeDlg->m_pPerTradeOther[i] == NULL)	
 				{

--- a/src/game/UICharacterCreate.cpp
+++ b/src/game/UICharacterCreate.cpp
@@ -147,7 +147,7 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 		dwResrcID_Races[3] = -1;
 	}
 
-	for(i = 0; i < MAX_RACE_SELECT; i++)
+	for(int i = 0; i < MAX_RACE_SELECT; i++)
 	{
 		if(szBtnIDs[i].empty()) continue;
 		m_pBtn_Races[i] = (CN3UIButton*)(this->GetChildByID(szBtnIDs[i])); __ASSERT(m_pBtn_Races[i], "NULL UI Component!!");
@@ -172,7 +172,7 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 		dwResrcID_Classes[3] = IDS_NEWCHR_KA_PRIEST;
 	}
 
-	for(i = 0; i < MAX_CLASS_SELECT; i++)
+	for(int i = 0; i < MAX_CLASS_SELECT; i++)
 	{
 		m_pBtn_Classes[i] =	(CN3UIButton*)(this->GetChildByID(szBtns[i]));	__ASSERT(m_pBtn_Classes[i], "NULL UI Component!!");
 		m_pImg_Disable_Classes[i] = (CN3UIImage*)(this->GetChildByID(szImgs2[i]));	__ASSERT(m_pImg_Disable_Classes[i], "NULL UI Component!!");
@@ -451,7 +451,7 @@ void CUICharacterCreate::Reset()
 	}
 
 	int iStats[MAX_STATS] = { pInfoExt->iStrength, pInfoExt->iStamina, pInfoExt->iDexterity, pInfoExt->iIntelligence, pInfoExt->iMagicAttak };
-	for(i = 0; i < MAX_STATS; i++)
+	for(int i = 0; i < MAX_STATS; i++)
 	{
 		if(m_pImg_Stats[i]) m_pImg_Stats[i]->SetVisible(false);
 		if(m_pStr_Stats[i]) m_pStr_Stats[i]->SetStringAsInt(iStats[i]);
@@ -473,7 +473,7 @@ DWORD CUICharacterCreate::MouseProc(DWORD dwFlags, const POINT& ptCur, const POI
 				break;
 			}
 		}
-		for(i = 0; i < MAX_CLASS_SELECT; i++)
+		for(int i = 0; i < MAX_CLASS_SELECT; i++)
 		{
 			if(m_pBtn_Classes[i] && m_pBtn_Classes[i]->IsIn(ptCur.x, ptCur.y))
 			{
@@ -481,7 +481,7 @@ DWORD CUICharacterCreate::MouseProc(DWORD dwFlags, const POINT& ptCur, const POI
 				break;
 			}
 		}
-		for(i = 0; i < MAX_RACE_SELECT; i++)
+		for(int i = 0; i < MAX_RACE_SELECT; i++)
 		{
 			if(m_pBtn_Races[i] && m_pBtn_Races[i]->IsIn(ptCur.x, ptCur.y))
 			{
@@ -559,7 +559,7 @@ void CUICharacterCreate::UpdateRaceAndClassButtons(e_Race eRace) // 종족에 따라 
 	for(int i = 0; i < MAX_RACE_SELECT; i++)
 		if(m_pBtn_Races[i]) m_pBtn_Races[i]->SetState(eUIStateRaces[i]);
 
-	for(i = 0; i < MAX_CLASS_SELECT; i++)
+	for(int i = 0; i < MAX_CLASS_SELECT; i++)
 	{
 		if(m_pBtn_Classes[i]) m_pBtn_Classes[i]->SetState(eUIStateClasses[i]);
 	
@@ -609,7 +609,7 @@ void CUICharacterCreate::UpdateClassButtons(e_Class eClass)
 	for(int i = 0; i < MAX_CLASS_SELECT; i++)
 		if(m_pBtn_Classes[i]) m_pBtn_Classes[i]->SetState(eUIStates[i]);
 
-	for(i = 0; i < MAX_STATS; i++) 
+	for(int i = 0; i < MAX_STATS; i++) 
 		if(m_pImg_Stats[i]) m_pImg_Stats[i]->SetVisible(bVisibles[i]);
 }
  

--- a/src/game/UIChat.cpp
+++ b/src/game/UIChat.cpp
@@ -207,9 +207,8 @@ bool CUIChat::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 
 void CUIChat::CreateLines()
 {
-	int i;
 	if (m_ppUILines) {
-		for (i=0; i<m_iChatLineCount; ++i)
+		for (int i=0; i<m_iChatLineCount; ++i)
 		{
 			if (m_ppUILines[i]) {delete m_ppUILines[i]; m_ppUILines[i] = NULL;}
 		}
@@ -228,7 +227,7 @@ void CUIChat::CreateLines()
 	if (m_iChatLineCount<=0 || szFontName.empty()) return;
 
 	m_ppUILines = new CN3UIString*[m_iChatLineCount];
-	for (i=0; i<m_iChatLineCount; ++i)
+	for (int i=0; i<m_iChatLineCount; ++i)
 	{
 		RECT rc;
 		SetRect(&rc, m_rcChatOutRegion.left, m_rcChatOutRegion.top+(i*size.cy),
@@ -483,12 +482,11 @@ void CUIChat::SetTopLine(int iTopLine)
 	if (iTopLine<0) iTopLine = 0;
 	else if (iTopLine > iLineBufferSize) iTopLine = iLineBufferSize;
 	
-	int i;
 	// 앞줄서부터 차례로 임시버퍼에 저장하고 string 길이 측정
 	__ChatInfo** ppLineInfos  = new __ChatInfo*[m_iChatLineCount];
 	ZeroMemory(ppLineInfos, sizeof(__ChatInfo*)*m_iChatLineCount);
 
-	int iCurLine = 0;
+	int i, iCurLine = 0;
 	for (i=0; i<m_iChatLineCount; ++i)
 	{
 		iCurLine = iTopLine + i;
@@ -501,14 +499,14 @@ void CUIChat::SetTopLine(int iTopLine)
 	// 앞에서부터 맞게 차례로 각각 버퍼에 넣기
 	int iRealLine = i;	// 실제 출력되는 줄 수
 	int iRealLineCount = 0;
-	for (i=0; i<iRealLine; ++i)
+	for (int i=0; i<iRealLine; ++i)
 	{
 		++iRealLineCount;
 		if (NULL == m_ppUILines[i]) continue;
 		m_ppUILines[i]->SetColor(ppLineInfos[i]->color);
 		m_ppUILines[i]->SetString(ppLineInfos[i]->szChat);
 	}
-	for (i=iRealLineCount; i<m_iChatLineCount; ++i)
+	for (int i=iRealLineCount; i<m_iChatLineCount; ++i)
 	{
 		if (NULL == m_ppUILines[i]) continue;
 		m_ppUILines[i]->SetString("");	// 나머지는 빈칸 만들기

--- a/src/game/UIDroppedItemDlg.cpp
+++ b/src/game/UIDroppedItemDlg.cpp
@@ -34,7 +34,7 @@
 CUIDroppedItemDlg::CUIDroppedItemDlg()
 {
 	for( int i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )	m_pMyDroppedItem[i] = NULL;
-	for( i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )	m_bSendedIconArray[i] = false;
+	for( int i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )	m_bSendedIconArray[i] = false;
 
 	m_iItemBundleID = 0;
 	m_pUITooltipDlg = NULL;
@@ -144,9 +144,7 @@ void CUIDroppedItemDlg::InitIconUpdate()
 {
 	CN3UIArea* pArea;
 	float fUVAspect = (float)45.0f/(float)64.0f;
-	int i;
-
-	for( i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )
+	for( int i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )
 	{
 		if ( m_pMyDroppedItem[i] )
 		{
@@ -183,8 +181,7 @@ void CUIDroppedItemDlg::EnterDroppedState(int xpos, int ypos)
 
 	SetPos(xpos, ypos-150);
 
-	int i;
-	for( i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )
+	for( int i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )
 	{
 		m_bSendedIconArray[i] = false;
 
@@ -332,10 +329,9 @@ bool CUIDroppedItemDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 
 int CUIDroppedItemDlg::GetInventoryEmptyInviOrder(__IconItemSkill* spItem)
 {
-	int i;
 	if (spItem == NULL)
 	{
-		for ( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+		for ( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 		{
 			if ( !CGameProcedure::s_pProcMain->m_pUIInventory->m_pMyInvWnd[i] )
 				return i;
@@ -343,14 +339,14 @@ int CUIDroppedItemDlg::GetInventoryEmptyInviOrder(__IconItemSkill* spItem)
 	}
 	else
 	{
-		for ( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+		for ( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 		{
 			if ( CGameProcedure::s_pProcMain->m_pUIInventory->m_pMyInvWnd[i] && 
 				(CGameProcedure::s_pProcMain->m_pUIInventory->m_pMyInvWnd[i]->pItemBasic->dwID == spItem->pItemBasic->dwID) )
 				return i;
 		}
 
-		for ( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+		for ( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 		{
 			if ( !CGameProcedure::s_pProcMain->m_pUIInventory->m_pMyInvWnd[i] )
 				return i;
@@ -362,9 +358,7 @@ int CUIDroppedItemDlg::GetInventoryEmptyInviOrder(__IconItemSkill* spItem)
 
 int	CUIDroppedItemDlg::GetItemiOrder(__IconItemSkill* spItem)
 {
-	int i;
-
-	for( i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )
+	for( int i = 0; i < MAX_ITEM_BUNDLE_DROP_PIECE; i++ )
 	{
 		if ( (m_pMyDroppedItem[i] != NULL) && (m_pMyDroppedItem[i] == spItem) )
 			return i;
@@ -480,7 +474,7 @@ void CUIDroppedItemDlg::GetItemByIDToInventory(BYTE bResult, int iItemID, int iG
 	__TABLE_ITEM_BASIC*	pItem = NULL;									// 아이템 테이블 구조체 포인터..
 	__TABLE_ITEM_EXT*	pItemExt = NULL;
 	__IconItemSkill*	spItem = NULL;
-	int i;
+	int i = 0;
 	char szMsg[32];
 	CN3UIString* pStatic = NULL;
 	__InfoPlayerMySelf*	pInfoExt = NULL;

--- a/src/game/UIHelp.cpp
+++ b/src/game/UIHelp.cpp
@@ -76,7 +76,7 @@ bool CUIHelp::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 
 		if(iPagePrev != iPage)
 		{
-			for(i = 0; i < MAX_HELP_PAGE; i++)
+			for(int i = 0; i < MAX_HELP_PAGE; i++)
 			{
 				if(NULL == m_pPages[i]) continue;
 

--- a/src/game/UIHotKeyDlg.cpp
+++ b/src/game/UIHotKeyDlg.cpp
@@ -315,7 +315,8 @@ void CUIHotKeyDlg::Render()
 	CN3UIArea* pArea;
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
 
-	for( int k = 0; k < MAX_SKILL_IN_HOTKEY; k++ )
+	int k;
+	for( k = 0; k < MAX_SKILL_IN_HOTKEY; k++ )
 	{
 		if (m_pMyHotkey[m_iCurPage][k] != NULL) 
 			DisplayCountStr(m_pMyHotkey[m_iCurPage][k]);
@@ -433,16 +434,13 @@ void CUIHotKeyDlg::InitIconUpdate()
 
 void CUIHotKeyDlg::UpdateDisableCheck()
 {
-	int i, j;
-	DWORD bitMask;
-
-	for( i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
+	for( int i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
 	{
-		for( j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
+		for( int j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
 		{
 			if ( m_pMyHotkey[i][j] != NULL )
 			{
-				bitMask = UISTYLE_ICON_SKILL;
+				DWORD bitMask = UISTYLE_ICON_SKILL;
 				if (!CGameProcedure::s_pProcMain->m_pMagicSkillMng->CheckValidSkillMagic(m_pMyHotkey[i][j]->pSkill))
 					bitMask |= UISTYLE_DISABLE_SKILL;
 				m_pMyHotkey[i][j]->pUIIcon->SetStyle(bitMask);
@@ -455,13 +453,10 @@ void CUIHotKeyDlg::CloseIconRegistry()
 {
 	// Save Hotkey Data to Registry.. 
 	// First, Saving Hotkey Data Count.. 
-
-	int i, j;
-
 	int iHCount = 0;
-	for( i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
+	for( int i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
 	{
-		for( j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
+		for( int j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
 		{
 			if ( m_pMyHotkey[i][j] != NULL )
 				iHCount++;
@@ -473,9 +468,9 @@ void CUIHotKeyDlg::CloseIconRegistry()
 	char szSkill[32];
 	int iSkillCount = 0;
 
-	for( i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
+	for( int i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
 	{
-		for( j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
+		for( int j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
 		{
 			if ( m_pMyHotkey[i][j] != NULL )
 			{
@@ -556,7 +551,8 @@ bool CUIHotKeyDlg::IsSelectedSkillInRealIconArea()
 	bool bFound = false;
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
 
-	for( int i = 0; i < MAX_SKILL_IN_HOTKEY; i++ )
+	int i;
+	for( i = 0; i < MAX_SKILL_IN_HOTKEY; i++ )
 	{
 		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_SKILL_HOTKEY, i);
 		if (pArea && pArea->IsIn(ptCur.x, ptCur.y))
@@ -652,20 +648,18 @@ void CUIHotKeyDlg::PageDown()
 }
 
 void CUIHotKeyDlg::SetHotKeyPage(int iPageNum)
-{
-	int i, j;
-	
-	for( i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
+{	
+	for( int i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++ )
 	{
 		if ( i != iPageNum )
 		{
-			for( j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
+			for( int j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
 				if ( m_pMyHotkey[i][j] != NULL )
 					m_pMyHotkey[i][j]->pUIIcon->SetVisible(false);
 		}
 		else
 		{
-			for( j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
+			for( int j = 0; j < MAX_SKILL_IN_HOTKEY; j++ )
 				if ( m_pMyHotkey[i][j] != NULL )
 					m_pMyHotkey[i][j]->pUIIcon->SetVisible(true);
 		}

--- a/src/game/UIImageTooltipDlg.cpp
+++ b/src/game/UIImageTooltipDlg.cpp
@@ -132,7 +132,7 @@ void CUIImageTooltipDlg::SetPosSomething(int xpos, int ypos, int iNum)
 	SetPos(iX, iY);
 	SetSize(rect.right - rect.left, rect.bottom - rect.top);
 
-	for (i = 0; i < iNum; i++)
+	for (int i = 0; i < iNum; i++)
 	{
 		if (!m_pStr[i])	continue;		
 		rect2 = m_pStr[i]->GetRegion();
@@ -144,7 +144,7 @@ void CUIImageTooltipDlg::SetPosSomething(int xpos, int ypos, int iNum)
 			m_pStr[i]->SetString("  "+m_pstdstr[i]);
 	}
 
-	for (i = iNum; i < MAX_TOOLTIP_COUNT; i++ )
+	for (int i = iNum; i < MAX_TOOLTIP_COUNT; i++ )
 		m_pStr[i]->SetString("");
 
 	m_pImg->SetRegion(rect);

--- a/src/game/UIInventory.cpp
+++ b/src/game/UIInventory.cpp
@@ -67,7 +67,7 @@ static bool g_bItemClassGroup[26][26] = {	// [아이템][플레이어]
 CUIInventory::CUIInventory()
 {
 	for( int i = 0; i < ITEM_SLOT_COUNT; i++ )	m_pMySlot[i] = NULL;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyInvWnd[i] = NULL;
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyInvWnd[i] = NULL;
 
 	m_pUITooltipDlg = NULL;
 	CN3UIWndBase::m_sRecoveryJobInfo.m_bWaitFromServer = false;
@@ -101,7 +101,7 @@ void CUIInventory::Release()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyInvWnd[i] != NULL )
 		{
@@ -145,7 +145,7 @@ void CUIInventory::ReleaseItem()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyInvWnd[i] != NULL )
 		{
@@ -428,7 +428,7 @@ void CUIInventory::InitIconUpdate()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyInvWnd[i] != NULL )
 		{
@@ -458,7 +458,7 @@ __IconItemSkill* CUIInventory::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 			return m_pMySlot[i];
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i]->pUIIcon == pUIIcon) )
 			return m_pMyInvWnd[i];
@@ -474,7 +474,7 @@ e_UIWND_DISTRICT CUIInventory::GetWndDistrict(__IconItemSkill* spItem)
 			return UIWND_DISTRICT_INVENTORY_SLOT;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i] == spItem) )
 			return UIWND_DISTRICT_INVENTORY_INV;
@@ -485,12 +485,10 @@ e_UIWND_DISTRICT CUIInventory::GetWndDistrict(__IconItemSkill* spItem)
 int CUIInventory::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWndDist)
 {
 	int iReturn = -1;
-	int i;
-
 	switch ( eWndDist )
 	{
 		case UIWND_DISTRICT_INVENTORY_SLOT:
-			for( i = 0; i < ITEM_SLOT_COUNT; i++ )
+			for( int i = 0; i < ITEM_SLOT_COUNT; i++ )
 			{
 				if ( (m_pMySlot[i] != NULL) && (m_pMySlot[i] == spItem) )
 					return i;
@@ -498,7 +496,7 @@ int CUIInventory::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWndDi
 			break;
 
 		case UIWND_DISTRICT_INVENTORY_INV:
-			for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+			for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 			{
 				if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i] == spItem) )
 					return i;
@@ -1415,7 +1413,7 @@ int CUIInventory::GetIndexInArea(POINT pt)
 		}
 	}
 
-	for (i = 0; i < MAX_ITEM_INVENTORY; i++)
+	for (int i = 0; i < MAX_ITEM_INVENTORY; i++)
 	{
 		pArea = NULL;
 		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_INV, i);
@@ -2360,8 +2358,7 @@ void CUIInventory::ReceiveResultFromServer(int iResult, int iUserGold)
 
 int CUIInventory::GetCountInInvByID(int iID)
 {
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i]->pItemBasic->dwID == (iID/1000*1000)) &&
 				(m_pMyInvWnd[i]->pItemExt->dwID == (iID%1000)) )
@@ -2852,7 +2849,7 @@ int CUIInventory::GetIndexItemCount(DWORD dwIndex)
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(m_pMyInvWnd[i] && m_pMyInvWnd[i]->pItemBasic)
 		{

--- a/src/game/UIItemExchange.cpp
+++ b/src/game/UIItemExchange.cpp
@@ -25,18 +25,17 @@ CUIItemExchange::CUIItemExchange()
 {
 	m_pUITooltipDlg = NULL;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		m_pMyInvWnd[i] = NULL;
 	}
 
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		m_pMyNpcWnd[i] = NULL;
 	}
 
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		m_pMyNpcWndOriginIndex[i] = -1;
 	}
@@ -62,7 +61,7 @@ void CUIItemExchange::Release()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		if ( m_pMyNpcWnd[i] != NULL )
 		{
@@ -121,8 +120,7 @@ void CUIItemExchange::InitIconWnd(e_UIWND eWnd)
 
 __IconItemSkill* CUIItemExchange::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 {
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i]->pUIIcon == pUIIcon) )
 			return m_pMyInvWnd[i];
@@ -133,12 +131,10 @@ __IconItemSkill* CUIItemExchange::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 
 int	CUIItemExchange::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWndDist)
 {
-	int i;
-
 	switch ( eWndDist )
 	{
 		case UIWND_DISTRICT_EX_RE_INV:
-			for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+			for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 			{
 				if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i] == spItem) )
 					return i;
@@ -157,7 +153,7 @@ e_UIWND_DISTRICT CUIItemExchange::GetWndDistrict(__IconItemSkill* spItem)
 			return UIWND_DISTRICT_EX_RE_INV;
 	}
 
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		if ( (m_pMyNpcWnd[i] != NULL) && (m_pMyNpcWnd[i] == spItem) )
 			return UIWND_DISTRICT_EX_RE_NPC;
@@ -225,7 +221,8 @@ bool CUIItemExchange::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 		FAIL_RETURN
 
 	// 내가 가졌던 아이콘이면.. npc영역인지 검사한다..
-	int i; bool bFound = false;
+	bool bFound = false;
+	int i;
 	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_REPAIR_NPC, i);
@@ -408,13 +405,12 @@ void CUIItemExchange::Open()
 
 
 	// 기타 작업..
-	int i;
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		m_pMyNpcWnd[i] = NULL;
 	}
 
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		m_pMyNpcWndOriginIndex[i] = -1;
 	}
@@ -444,7 +440,7 @@ void CUIItemExchange::UserPressOK()
 
 	CAPISocket::MP_AddByte(byBuff, iOffset, N3_ITEM_REPAIR_REQUEST);			// 게임 스타트 패킷 커멘드..
 	CAPISocket::MP_AddShort(byBuff, iOffset, iCount);		// 아이디 길이 패킷에 넣기..
-	for( i = 0; i < iCount; i++ )
+	for( int i = 0; i < iCount; i++ )
 	{
 		CAPISocket::MP_AddByte(byBuff, iOffset, m_pMyNpcWndOriginIndex[i]);		// 아이디 길이 패킷에 넣기..
 		CAPISocket::MP_AddDword(byBuff, iOffset, m_pMyNpcWnd[i]->pItemBasic->dwID+m_pMyNpcWnd[i]->pItemExt->dwID);	// 아이디 문자열 패킷에 넣기..
@@ -505,8 +501,7 @@ void CUIItemExchange::UserPressCancel()
 	CN3UIArea* pArea = NULL;
 
 	// 이 윈도우의 npc 영역의 아이템을 이 윈도우의 inv 영역으로 옮긴다..
-	int i;
-	for( i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
+	for( int i = 0; i < MAX_ITEM_EX_RE_NPC; i++ )
 	{
 		if(m_pMyNpcWnd[i])
 		{
@@ -539,13 +534,12 @@ void CUIItemExchange::ItemMoveFromInvToThis()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		m_pMyInvWnd[i] = NULL;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(pInven->m_pMyInvWnd[i])
 		{
@@ -572,8 +566,7 @@ void CUIItemExchange::ItemMoveFromThisToInv()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(m_pMyInvWnd[i])
 		{

--- a/src/game/UIManager.cpp
+++ b/src/game/UIManager.cpp
@@ -157,8 +157,7 @@ void CUIManager::ReorderChildList()	// 다이알로그 순서 재배치
 		}
 		else ++itor;
 	}
-	int i;
-	for (i=iAlwaysTopChildCount-1; i>=0; --i)
+	for (int i=iAlwaysTopChildCount-1; i>=0; --i)
 	{
 		m_Children.push_front(ppBuffer[i]);	// 맨앞에 넣는다. 그리는 순서를 맨 나중에 그리도록 하고 메세지를 맨 먼저 받게 하려고
 	}

--- a/src/game/UIMessageWnd.cpp
+++ b/src/game/UIMessageWnd.cpp
@@ -133,9 +133,8 @@ bool CUIMessageWnd::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 
 void CUIMessageWnd::CreateLines()
 {
-	int i;
 	if (m_ppUILines) {
-		for (i=0; i<m_iChatLineCount; ++i)
+		for (int i=0; i<m_iChatLineCount; ++i)
 		{
 			if (m_ppUILines[i]) {delete m_ppUILines[i]; m_ppUILines[i] = NULL;}
 		}
@@ -154,7 +153,7 @@ void CUIMessageWnd::CreateLines()
 	if (m_iChatLineCount<=0 || szFontName.size() <= 0) return;
 
 	m_ppUILines = new CN3UIString*[m_iChatLineCount];
-	for (i=0; i<m_iChatLineCount; ++i)
+	for (int i=0; i<m_iChatLineCount; ++i)
 	{
 		RECT rc;
 		SetRect(&rc, m_rcChatOutRegion.left, m_rcChatOutRegion.top+(i*size.cy),
@@ -311,12 +310,11 @@ void CUIMessageWnd::SetTopLine(int iTopLine)
 	if (iTopLine<0) iTopLine = 0;
 	else if (iTopLine > iLineBufferSize) iTopLine = iLineBufferSize;
 	
-	int i;
 	// 앞줄서부터 차례로 임시버퍼에 저장하고 string 길이 측정
 	__ChatInfo** ppLineInfos  = new __ChatInfo*[m_iChatLineCount];
 	ZeroMemory(ppLineInfos, sizeof(__ChatInfo*)*m_iChatLineCount);
 
-	int iCurLine = 0;
+	int i, iCurLine = 0;
 	for (i=0; i<m_iChatLineCount; ++i)
 	{
 		iCurLine = iTopLine + i;

--- a/src/game/UIPartyOrForce.cpp
+++ b/src/game/UIPartyOrForce.cpp
@@ -274,7 +274,8 @@ void CUIPartyOrForce::MemberInfoReInit() // 파티원 구성이 변경될때.. 순서 및 각�
 {
 	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
 	__InfoPartyOrForce* pIP = NULL;
-	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
+	int i;
+	for(i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{
 		pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
 		if(pIP->iHPMax <= 0)

--- a/src/game/UIPerTradeDlg.cpp
+++ b/src/game/UIPerTradeDlg.cpp
@@ -32,9 +32,9 @@ CUIPerTradeDlg::CUIPerTradeDlg()
 {
 	m_pSubProcPerTrade = NULL;
 	for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )	m_pPerTradeMy[i] = NULL;
-	for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )	m_pPerTradeOther[i] = NULL;
-	for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )	m_iBackupiOrder[i] = -1;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pPerTradeInv[i] = NULL;
+	for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )	m_pPerTradeOther[i] = NULL;
+	for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )	m_iBackupiOrder[i] = -1;
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pPerTradeInv[i] = NULL;
 
 	m_iBackupiCount = 0;
 	m_pUITooltipDlg = NULL;
@@ -63,7 +63,7 @@ void CUIPerTradeDlg::Release()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )
 	{
 		if ( m_pPerTradeOther[i] != NULL )
 		{
@@ -72,7 +72,7 @@ void CUIPerTradeDlg::Release()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pPerTradeInv[i] != NULL )
 		{
@@ -129,7 +129,7 @@ void CUIPerTradeDlg::Render()
 	}
 
 	// 갯수 표시되야 할 아이템 갯수 표시..
-	for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )
 	{
 		if ( m_pPerTradeOther[i] && ( (m_pPerTradeOther[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || (m_pPerTradeOther[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ) )
 		{
@@ -152,7 +152,7 @@ void CUIPerTradeDlg::Render()
 	}
 
 	// 갯수 표시되야 할 아이템 갯수 표시..
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pPerTradeInv[i] && ( (m_pPerTradeInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || (m_pPerTradeInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ) )
 		{
@@ -233,13 +233,13 @@ __IconItemSkill* CUIPerTradeDlg::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 			return m_pPerTradeMy[i];
 	}
 
-	for( i = 0; i < MAX_ITEM_PER_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_PER_TRADE; i++ )
 	{
 		if ( (m_pPerTradeOther[i] != NULL) && (m_pPerTradeOther[i]->pUIIcon == pUIIcon) )
 			return m_pPerTradeOther[i];
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pPerTradeInv[i] != NULL) && (m_pPerTradeInv[i]->pUIIcon == pUIIcon) ) 
 			return m_pPerTradeInv[i];
@@ -277,7 +277,7 @@ void CUIPerTradeDlg::EnterPerTradeState()
 	pButton = (CN3UIButton* )GetChildButtonByName(szFN);
 	if(pButton) pButton->SetState(UI_STATE_BUTTON_NORMAL);
 
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
 		if ( m_pPerTradeMy[i] != NULL )
 		{
@@ -293,7 +293,7 @@ void CUIPerTradeDlg::EnterPerTradeState()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
 		if ( m_pPerTradeOther[i] != NULL )
 		{
@@ -309,7 +309,7 @@ void CUIPerTradeDlg::EnterPerTradeState()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pPerTradeInv[i] != NULL )
 		{
@@ -344,8 +344,7 @@ void CUIPerTradeDlg::ItemMoveFromInvToThis()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(pInven->m_pMyInvWnd[i])
 		{
@@ -372,8 +371,7 @@ void CUIPerTradeDlg::ItemMoveFromThisToInv()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(m_pPerTradeInv[i])
 		{
@@ -742,13 +740,10 @@ DWORD CUIPerTradeDlg::MouseProc(DWORD dwFlags, const POINT& ptCur, const POINT& 
 
 int	CUIPerTradeDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWndDist)
 {
-	int iReturn = -1;
-	int i;
-
 	switch ( eWndDist )
 	{
 		case UIWND_DISTRICT_PER_TRADE_INV:
-			for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+			for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 			{
 				if ( (m_pPerTradeInv[i] != NULL) && (m_pPerTradeInv[i] == spItem) )
 					return i;
@@ -756,7 +751,7 @@ int	CUIPerTradeDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWnd
 			break;
 	}
 
-	return iReturn;
+	return -1;
 }
 
 RECT CUIPerTradeDlg::GetSampleRect()

--- a/src/game/UISkillTreeDlg.cpp
+++ b/src/game/UISkillTreeDlg.cpp
@@ -35,18 +35,15 @@ CUISkillTreeDlg::CUISkillTreeDlg()
 	m_fMoveDelta = 0.0f; // 부드럽게 열리고 닫히게 만들기 위해서 현재위치 계산에 부동소수점을 쓴다..
 
 	m_iRBtnDownOffs = -1;
-
-	int i, j, k;
-
 	m_iCurKindOf		= 0;
 	m_iCurSkillPage		= 0;
 
-	for( i = 0; i < MAX_SKILL_FROM_SERVER; i++ )
+	for( int i = 0; i < MAX_SKILL_FROM_SERVER; i++ )
 		m_iSkillInfo[i] = NULL;
 
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
-		for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
-			for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
+		for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+			for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 				m_pMySkillTree[i][j][k] = NULL;	
 			
 	CN3UIWndBase::m_sSkillSelectInfo.UIWnd = UIWND_HOTKEY;
@@ -56,11 +53,10 @@ CUISkillTreeDlg::CUISkillTreeDlg()
 CUISkillTreeDlg::~CUISkillTreeDlg()
 {
 	Release();
-/*	int i, j, k;
-
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
-		for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
-			for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+/*
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
+		for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+			for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 				if ( m_pMySkillTree[i][j][k] != NULL )
 				{
 					delete m_pMySkillTree[i][j][k];
@@ -82,13 +78,11 @@ void CUISkillTreeDlg::Release()
 	m_bClosingNow = false;	// 닫히고 있다..
 	m_fMoveDelta = 0.0f; // 부드럽게 열리고 닫히게 만들기 위해서 현재위치 계산에 부동소수점을 쓴다..
 
-	int i, j, k;
-
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
 	{
-		for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+		for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
 		{
-			for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+			for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 			{
 				if ( m_pMySkillTree[i][j][k] != NULL )
 				{
@@ -108,11 +102,9 @@ void CUISkillTreeDlg::Release()
 
 bool CUISkillTreeDlg::HasIDSkill(int iID)
 {
-	int i, j, k;
-
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
-		for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
-			for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
+		for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+			for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 				if ( m_pMySkillTree[i][j][k] != NULL )
 				{
 					if ( m_pMySkillTree[i][j][k]->pSkill->dwID == iID )
@@ -124,15 +116,12 @@ bool CUISkillTreeDlg::HasIDSkill(int iID)
 
 void CUISkillTreeDlg::UpdateDisableCheck()
 {
-	int i, j, k;
-	DWORD bitMask;
-
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
-		for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
-			for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
+		for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+			for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 				if ( m_pMySkillTree[i][j][k] != NULL )
 				{
-					bitMask = UISTYLE_ICON_SKILL;
+					DWORD bitMask = UISTYLE_ICON_SKILL;
 					if (!CGameProcedure::s_pProcMain->m_pMagicSkillMng->CheckValidSkillMagic(m_pMySkillTree[i][j][k]->pSkill))
 						bitMask |= UISTYLE_DISABLE_SKILL;
 					m_pMySkillTree[i][j][k]->pUIIcon->SetStyle(bitMask);
@@ -1041,13 +1030,12 @@ void CUISkillTreeDlg::InitIconWnd(e_UIWND eWnd)
 
 void CUISkillTreeDlg::InitIconUpdate()
 {
-	int i, j, k, iDivide;
 	__TABLE_UPC_SKILL* pUSkill = NULL;
 
 	// 기존 아이콘 모두 클리어..
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
-		for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
-			for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
+		for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+			for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 				if ( m_pMySkillTree[i][j][k] != NULL )
 				{
 					__IconItemSkill* spSkill = m_pMySkillTree[i][j][k];
@@ -1079,10 +1067,10 @@ void CUISkillTreeDlg::InitIconUpdate()
 
 	if ( CGameBase::s_pPlayer->m_InfoBase.eClass != CLASS_EL_DRUID )
 	{
-		for( i = iSkillIndexFirst; i < CGameBase::s_pTbl_Skill->GetSize(); i++ )
+		for( int i = iSkillIndexFirst; i < CGameBase::s_pTbl_Skill->GetSize(); i++ )
 		{
 			pUSkill = CGameBase::s_pTbl_Skill->GetIndexedData(i);
-			iDivide = pUSkill->dwID / 1000;
+			int iDivide = pUSkill->dwID / 1000;
 			if ( iDivide != (iSkillIDFirst / 1000) )
 			{
 				iSkillIndexLast = i;
@@ -1091,7 +1079,7 @@ void CUISkillTreeDlg::InitIconUpdate()
 		}
 	}
 
-	for( i = iSkillIndexFirst; i < iSkillIndexLast; i++ )
+	for( int i = iSkillIndexFirst; i < iSkillIndexLast; i++ )
 	{
 		__TABLE_UPC_SKILL* pUSkill = CGameBase::s_pTbl_Skill->GetIndexedData(i);
 		if ( pUSkill == NULL ) continue;
@@ -1443,14 +1431,12 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum)		// 아이콘 
 	m_iCurKindOf		= iKindOf;
 	m_iCurSkillPage		= iPageNum;
 
-	int i, j, k;
-
-	for( i = 0; i < MAX_SKILL_KIND_OF; i++ )
+	for( int i = 0; i < MAX_SKILL_KIND_OF; i++ )
 	{
 		if ( i != iKindOf )
 		{
-			for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
-				for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+			for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+				for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 				{
 					if ( m_pMySkillTree[i][j][k] != NULL )
 						m_pMySkillTree[i][j][k]->pUIIcon->SetVisible(false);
@@ -1458,11 +1444,11 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum)		// 아이콘 
 		}
 		else
 		{
-			for( j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
+			for( int j = 0; j < MAX_SKILL_PAGE_NUM; j++ )
 			{
 				if( j != iPageNum )
 				{
-					for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+					for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 					{
 						if ( m_pMySkillTree[i][j][k] != NULL )
 							m_pMySkillTree[i][j][k]->pUIIcon->SetVisible(false);
@@ -1470,7 +1456,7 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum)		// 아이콘 
 				}
 				else
 				{
-					for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+					for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 					{
 						if ( m_pMySkillTree[i][j][k] != NULL )
 							m_pMySkillTree[i][j][k]->pUIIcon->SetVisible(true);
@@ -1485,7 +1471,7 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum)		// 아이콘 
 	std::string str; 
 	char	cstr[4];
 
-	for( k = 0; k < MAX_SKILL_IN_PAGE; k++ )
+	for( int k = 0; k < MAX_SKILL_IN_PAGE; k++ )
 	{
 		if ( m_pMySkillTree[m_iCurKindOf][m_iCurSkillPage][k] != NULL )
 		{
@@ -1531,7 +1517,7 @@ void CUISkillTreeDlg::AllClearImageByName(const std::string& szFN, bool bTrueOrN
 	pBase = GetChildBaseByName(str);
 	if (pBase) pBase->SetVisible(bTrueOrNot);
 
-	for ( i = 0; i < 4; i++ )
+	for ( int i = 0; i < 4; i++ )
 	{
 		str = "btn_";	str += szFN;	sprintf(cstr, "%d", i);	str+= cstr;
 		pButton = GetChildButtonByName(str);

--- a/src/game/UITradeList.cpp
+++ b/src/game/UITradeList.cpp
@@ -81,7 +81,7 @@ void CUITradeList::Open(int iIDTarget)
 	__TABLE_ITEM_BASIC* pItem = NULL;
 
 	// 아이디 = 직업 코드*1000 + 001부터.. (직업 코드+1)*100 + 001까지..
-	int i, iIDFirst, iIDIndexFirst, iIDIndexLast, iDivide, iTotalCount;
+	int iIDFirst, iIDIndexFirst, iIDIndexLast, iDivide, iTotalCount;
 	iIDFirst = iIDTarget*1000+1;
 	iIDIndexFirst = CGameBase::s_pTbl_Exchange_Quest->IDToIndex(iIDFirst);
 
@@ -91,7 +91,7 @@ void CUITradeList::Open(int iIDTarget)
 	iTotalCount = CGameBase::s_pTbl_Exchange_Quest->GetSize();
 	iIDIndexLast = 0;
 
-	for( i = iIDIndexFirst; i < iTotalCount; i++ )
+	for( int i = iIDIndexFirst; i < iTotalCount; i++ )
 	{
 		pQuest = CGameBase::s_pTbl_Exchange_Quest->GetIndexedData(i);
 		if (!pQuest) 
@@ -112,7 +112,7 @@ void CUITradeList::Open(int iIDTarget)
 
 	// 메시지 박스 텍스트 표시..
 	char pszID[32];
-	for( i = iIDIndexFirst; i < iIDIndexFirst + 40; i++ )
+	for( int i = iIDIndexFirst; i < iIDIndexFirst + 40; i++ )
 	{
 		pQuest						= CGameBase::s_pTbl_Exchange_Quest->GetIndexedData(i);
 		if (pQuest)

--- a/src/game/UITransactionDlg.cpp
+++ b/src/game/UITransactionDlg.cpp
@@ -33,12 +33,11 @@
 
 CUITransactionDlg::CUITransactionDlg()
 {
-	int i, j;
 	m_iCurPage = 0;
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )		
+	for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )		
 			m_pMyTrade[j][i] = NULL;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyTradeInv[i] = NULL;
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyTradeInv[i] = NULL;
 
 	m_pUITooltipDlg = NULL;
 	m_pStrMyGold    = NULL;
@@ -59,9 +58,8 @@ void CUITransactionDlg::Release()
 {
 	CN3UIBase::Release();
 
-	int i, j;
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
 			if ( m_pMyTrade[j][i] != NULL )
 			{
@@ -70,7 +68,7 @@ void CUITransactionDlg::Release()
 			}
 		}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyTradeInv[i] != NULL )
 		{
@@ -83,8 +81,6 @@ void CUITransactionDlg::Release()
 void CUITransactionDlg::Render()
 {
 	if (!m_bVisible) return;	// 보이지 않으면 자식들을 render하지 않는다.
-
-	int i;
 
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
 	m_pUITooltipDlg->DisplayTooltipsDisable();
@@ -107,7 +103,7 @@ void CUITransactionDlg::Render()
 	}
 
 	// 갯수 표시되야 할 아이템 갯수 표시..
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyTradeInv[i] && ( (m_pMyTradeInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || 
 			(m_pMyTradeInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ) )
@@ -186,10 +182,9 @@ void CUITransactionDlg::InitIconUpdate()
 {
 	CN3UIArea* pArea;
 	float fUVAspect = (float)45.0f/(float)64.0f;
-	int i, j;
 
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
 			if ( m_pMyTrade[j][i] != NULL )
 			{
@@ -211,14 +206,13 @@ void CUITransactionDlg::InitIconUpdate()
 
 __IconItemSkill* CUITransactionDlg::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 {
-	int i;
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
 		if ( (m_pMyTrade[m_iCurPage][i] != NULL) && (m_pMyTrade[m_iCurPage][i]->pUIIcon == pUIIcon) )
 			return m_pMyTrade[m_iCurPage][i];
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyTradeInv[i] != NULL) && (m_pMyTradeInv[i]->pUIIcon == pUIIcon) ) 
 			return m_pMyTradeInv[i];
@@ -229,9 +223,8 @@ __IconItemSkill* CUITransactionDlg::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 
 void CUITransactionDlg::EnterTransactionState()
 {
-	int i, j;
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
 			if ( m_pMyTrade[j][i] != NULL )
 			{
@@ -247,7 +240,7 @@ void CUITransactionDlg::EnterTransactionState()
 			}
 		}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyTradeInv[i] != NULL )
 		{
@@ -272,8 +265,7 @@ void CUITransactionDlg::EnterTransactionState()
 	int iExt = m_iTradeID%1000;
 	int iSize = CGameBase::s_pTbl_Items_Basic->GetSize();
 
-	j = 0;	int k = 0;
-	for ( i = 0; i < iSize; i++ )
+	for (int i = 0, j = 0, k = 0; i < iSize; i++, k++)
 	{
 		if (k >= MAX_ITEM_TRADE)
 		{
@@ -320,9 +312,7 @@ void CUITransactionDlg::EnterTransactionState()
 		spItem->iCount		= 1;
 		spItem->iDurability = pItem->siMaxDurability+pItemExt->siMaxDurability;
 
-		m_pMyTrade[j][k] = spItem; 
-
-		k++;
+		m_pMyTrade[j][k] = spItem;
 	}
 
 	InitIconUpdate();
@@ -335,11 +325,11 @@ void CUITransactionDlg::EnterTransactionState()
 		pStr->SetString(pszID);
 	}
 
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+	for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
 	{
 		if (j == m_iCurPage)
 		{
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
 				if ( m_pMyTrade[j][i] != NULL )
 					m_pMyTrade[j][i]->pUIIcon->SetVisible(true);
@@ -347,7 +337,7 @@ void CUITransactionDlg::EnterTransactionState()
 		}
 		else
 		{
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
 				if ( m_pMyTrade[j][i] != NULL )
 					m_pMyTrade[j][i]->pUIIcon->SetVisible(false);
@@ -391,13 +381,12 @@ void CUITransactionDlg::ItemMoveFromInvToThis()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		m_pMyTradeInv[i] = NULL;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(pInven->m_pMyInvWnd[i])
 		{
@@ -441,8 +430,7 @@ void CUITransactionDlg::ItemMoveFromThisToInv()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(m_pMyTradeInv[i])
 		{
@@ -1319,13 +1307,10 @@ DWORD CUITransactionDlg::MouseProc(DWORD dwFlags, const POINT& ptCur, const POIN
 
 int CUITransactionDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWndDist)
 {
-	int iReturn = -1;
-	int i;
-
 	switch ( eWndDist )
 	{
 		case UIWND_DISTRICT_TRADE_NPC:
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
 				if ( (m_pMyTrade[m_iCurPage][i] != NULL) && (m_pMyTrade[m_iCurPage][i] == spItem) )
 					return i;
@@ -1333,7 +1318,7 @@ int CUITransactionDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT e
 			break;
 
 		case UIWND_DISTRICT_TRADE_MY:
-			for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+			for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 			{
 				if ( (m_pMyTradeInv[i] != NULL) && (m_pMyTradeInv[i] == spItem) )
 					return i;
@@ -1341,7 +1326,7 @@ int CUITransactionDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT e
 			break;
 	}
 
-	return iReturn;
+	return -1;
 }
 
 RECT CUITransactionDlg::GetSampleRect()
@@ -1367,7 +1352,7 @@ e_UIWND_DISTRICT CUITransactionDlg::GetWndDistrict(__IconItemSkill* spItem)
 			return UIWND_DISTRICT_TRADE_NPC;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyTradeInv[i] != NULL) && (m_pMyTradeInv[i] == spItem) )
 			return UIWND_DISTRICT_TRADE_MY;
@@ -1384,7 +1369,6 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 			}
 
 	if(NULL == pSender) return false;
-	int i, j;
 
 	if (dwMsg == UIMSG_BUTTON_CLICK)					
 	{
@@ -1407,11 +1391,11 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				pStr->SetString(pszID);
 			}
 
-			for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+			for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
 			{
 				if (j == m_iCurPage)
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyTrade[j][i] != NULL )
 							m_pMyTrade[j][i]->pUIIcon->SetVisible(true);
@@ -1419,7 +1403,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				}
 				else
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyTrade[j][i] != NULL )
 							m_pMyTrade[j][i]->pUIIcon->SetVisible(false);
@@ -1442,11 +1426,11 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				pStr->SetString(pszID);
 			}
 
-			for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+			for( int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
 			{
 				if (j == m_iCurPage)
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyTrade[j][i] != NULL )
 							m_pMyTrade[j][i]->pUIIcon->SetVisible(true);
@@ -1454,7 +1438,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				}
 				else
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyTrade[j][i] != NULL )
 							m_pMyTrade[j][i]->pUIIcon->SetVisible(false);

--- a/src/game/UIVarious.cpp
+++ b/src/game/UIVarious.cpp
@@ -921,10 +921,8 @@ void CUIKnights::RefreshPage()
 
 	it_KMI it = m_MemberList.begin();
 
-	int i = 10;
 	int e = m_iPageCur * 10;
-
-	for(;i<e;i++)
+	for(int i = 10;i<e;i++)
 	{
 		if(it==m_MemberList.end()) break;
 		it++;
@@ -932,7 +930,7 @@ void CUIKnights::RefreshPage()
 
 	std::string szDuty, szClass;
 	char szBuff[80];
-	for(i=0;i<10;i++)
+	for(int i=0;i<10;i++)
 	{
 		if(it==m_MemberList.end()) break;
 
@@ -1412,7 +1410,7 @@ void CUIFriends::UpdateList()
 	it_FI it = m_MapFriends.begin(), itEnd = m_MapFriends.end();
 	for(int i = 0; i < iSkip; i++, it++);
 
-	for(i = 0; i < iLinePerPage && it != itEnd; i++, it++)
+	for(int i = 0; i < iLinePerPage && it != itEnd; i++, it++)
 	{
 		__FriendsInfo& FI = it->second;
 		int iIndex = m_pList_Friends->AddString(FI.szName);

--- a/src/game/UIWareHouseDlg.cpp
+++ b/src/game/UIWareHouseDlg.cpp
@@ -34,12 +34,11 @@
 
 CUIWareHouseDlg::CUIWareHouseDlg()
 {
-	int i, j;
 	m_iCurPage = 0;
-	for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )		
+	for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )		
 			m_pMyWare[j][i] = NULL;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyWareInv[i] = NULL;
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyWareInv[i] = NULL;
 
 	m_pUITooltipDlg		= NULL;
 	m_pStrMyGold		= NULL;
@@ -66,9 +65,8 @@ void CUIWareHouseDlg::Release()
 {
 	CN3UIBase::Release();
 
-	int i, j;
-	for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
 			if ( m_pMyWare[j][i] != NULL )
 			{
@@ -77,7 +75,7 @@ void CUIWareHouseDlg::Release()
 			}
 		}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyWareInv[i] != NULL )
 		{
@@ -90,8 +88,6 @@ void CUIWareHouseDlg::Release()
 void CUIWareHouseDlg::Render()
 {
 	if (!m_bVisible) return;	// 보이지 않으면 자식들을 render하지 않는다.
-
-	int i;
 
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
 	m_pUITooltipDlg->DisplayTooltipsDisable();
@@ -114,7 +110,7 @@ void CUIWareHouseDlg::Render()
 	}
 
 	// 갯수 표시되야 할 아이템 갯수 표시..
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
 		if ( m_pMyWare[m_iCurPage][i] && ( (m_pMyWare[m_iCurPage][i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || 
 			(m_pMyWare[m_iCurPage][i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ) )
@@ -151,7 +147,7 @@ void CUIWareHouseDlg::Render()
 		}
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyWareInv[i] && ( (m_pMyWareInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE)  || (m_pMyWareInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL)  ) )
 		{
@@ -216,10 +212,9 @@ void CUIWareHouseDlg::InitIconUpdate()
 {
 	CN3UIArea* pArea;
 	float fUVAspect = (float)45.0f/(float)64.0f;
-	int i, j;
 
-	for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
 			if ( m_pMyWare[j][i] != NULL )
 			{
@@ -241,13 +236,10 @@ void CUIWareHouseDlg::InitIconUpdate()
 
 int CUIWareHouseDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWndDist)
 {
-	int iReturn = -1;
-	int i;
-
 	switch ( eWndDist )
 	{
 		case UIWND_DISTRICT_TRADE_NPC:
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
 				if ( (m_pMyWare[m_iCurPage][i] != NULL) && (m_pMyWare[m_iCurPage][i] == spItem) )
 					return i;
@@ -255,7 +247,7 @@ int CUIWareHouseDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWn
 			break;
 
 		case UIWND_DISTRICT_TRADE_MY:
-			for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+			for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 			{
 				if ( (m_pMyWareInv[i] != NULL) && (m_pMyWareInv[i] == spItem) )
 					return i;
@@ -263,7 +255,7 @@ int CUIWareHouseDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT eWn
 			break;
 	}
 
-	return iReturn;
+	return -1;
 }
 
 RECT CUIWareHouseDlg::GetSampleRect()
@@ -289,7 +281,7 @@ e_UIWND_DISTRICT CUIWareHouseDlg::GetWndDistrict(__IconItemSkill* spItem)
 			return UIWND_DISTRICT_TRADE_NPC;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyWareInv[i] != NULL) && (m_pMyWareInv[i] == spItem) )
 			return UIWND_DISTRICT_TRADE_MY;
@@ -323,7 +315,6 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 			}
 
 	if(NULL == pSender) return false;
-	int i, j;
 
 	if (dwMsg == UIMSG_BUTTON_CLICK)					
 	{
@@ -360,11 +351,11 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				pStr->SetString(pszID);
 			}
 
-			for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+			for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
 			{
 				if (j == m_iCurPage)
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyWare[j][i] != NULL )
 							m_pMyWare[j][i]->pUIIcon->SetVisible(true);
@@ -372,7 +363,7 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				}
 				else
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyWare[j][i] != NULL )
 							m_pMyWare[j][i]->pUIIcon->SetVisible(false);
@@ -395,11 +386,11 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				pStr->SetString(pszID);
 			}
 
-			for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+			for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
 			{
 				if (j == m_iCurPage)
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyWare[j][i] != NULL )
 							m_pMyWare[j][i]->pUIIcon->SetVisible(true);
@@ -407,7 +398,7 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase* pSender, DWORD dwMsg)
 				}
 				else
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 					{
 						if ( m_pMyWare[j][i] != NULL )
 							m_pMyWare[j][i]->pUIIcon->SetVisible(false);
@@ -487,9 +478,8 @@ void CUIWareHouseDlg::LeaveWareHouseState()
 
 void CUIWareHouseDlg::EnterWareHouseStateStart(int iWareGold)
 {
-	int i, j;
-	for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+		for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
 			if ( m_pMyWare[j][i] != NULL )
 			{
@@ -505,7 +495,7 @@ void CUIWareHouseDlg::EnterWareHouseStateStart(int iWareGold)
 			}
 		}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyWareInv[i] != NULL )
 		{
@@ -538,12 +528,11 @@ void CUIWareHouseDlg::EnterWareHouseStateEnd()
 		pStr->SetString(pszID);
 	}
 
-	int i, j;
-	for( j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
+	for( int j = 0; j < MAX_ITEM_WARE_PAGE; j++ )
 	{
 		if (j == m_iCurPage)
 		{
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
 				if ( m_pMyWare[j][i] != NULL )
 					m_pMyWare[j][i]->pUIIcon->SetVisible(true);
@@ -551,7 +540,7 @@ void CUIWareHouseDlg::EnterWareHouseStateEnd()
 		}
 		else
 		{
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
 				if ( m_pMyWare[j][i] != NULL )
 					m_pMyWare[j][i]->pUIIcon->SetVisible(false);
@@ -570,14 +559,13 @@ void CUIWareHouseDlg::EnterWareHouseStateEnd()
 
 __IconItemSkill* CUIWareHouseDlg::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 {
-	int i;
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
 		if ( (m_pMyWare[m_iCurPage][i] != NULL) && (m_pMyWare[m_iCurPage][i]->pUIIcon == pUIIcon) )
 			return m_pMyWare[m_iCurPage][i];
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( (m_pMyWareInv[i] != NULL) && (m_pMyWareInv[i]->pUIIcon == pUIIcon) ) 
 			return m_pMyWareInv[i];
@@ -1690,13 +1678,12 @@ void CUIWareHouseDlg::ItemMoveFromInvToThis()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		m_pMyWareInv[i] = NULL;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(pInven->m_pMyInvWnd[i])
 		{
@@ -1723,8 +1710,7 @@ void CUIWareHouseDlg::ItemMoveFromThisToInv()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(m_pMyWareInv[i])
 		{

--- a/src/server/AIServer/AIServer.vcxproj
+++ b/src/server/AIServer/AIServer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -97,7 +96,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/server/AIServer/GameSocket.cpp
+++ b/src/server/AIServer/GameSocket.cpp
@@ -1090,12 +1090,9 @@ void CGameSocket::RecvUserFail(char* pBuf)
 
 void CGameSocket::RecvBattleEvent(char* pBuf)
 {
-	int index = 0, i=0;
-	int nType = 0, nEvent = 0;
-	CNpc* pNpc = NULL;
-
-	nType = GetByte(pBuf,index);
-	nEvent = GetByte(pBuf,index);
+	int index = 0;
+	int nType = GetByte(pBuf,index);
+	int nEvent = GetByte(pBuf,index);
 
 	if( nEvent == BATTLEZONE_OPEN )	{
 		m_pMain->m_sKillKarusNpc = 0;
@@ -1113,8 +1110,8 @@ void CGameSocket::RecvBattleEvent(char* pBuf)
 
 	int nSize = m_pMain->m_arNpc.GetSize();
 
-	for( i = 0; i < nSize; i++)	{
-		pNpc = m_pMain->m_arNpc.GetData( i );
+	for( int i = 0; i < nSize; i++)	{
+		CNpc* pNpc = m_pMain->m_arNpc.GetData( i );
 		if( !pNpc ) continue;
 		if( pNpc->m_tNpcType > 10 && (pNpc->m_byGroup == KARUS_ZONE || pNpc->m_byGroup == ELMORAD_ZONE) )	{	// npc에만 적용되고, 국가에 소속된 npc
 			if( nEvent == BATTLEZONE_OPEN )	{		// 전쟁 이벤트 시작 (npc의 능력치 다운)

--- a/src/server/AIServer/IOCPort.cpp
+++ b/src/server/AIServer/IOCPort.cpp
@@ -403,7 +403,7 @@ void CIOCPort::DeleteAllArray()
 	}
 	delete[] m_SockArray;
 
-	for ( i=0; i < m_SocketArraySize; i++ ) {
+	for ( int i=0; i < m_SocketArraySize; i++ ) {
 		if ( m_SockArrayInActive[i] != NULL ) {
 			delete m_SockArrayInActive[i];
 			m_SockArrayInActive[i] = NULL;
@@ -411,7 +411,7 @@ void CIOCPort::DeleteAllArray()
 	}
 	delete[] m_SockArrayInActive;
 
-	for ( i=0; i < m_ClientSockSize; i++ ) {
+	for ( int i=0; i < m_ClientSockSize; i++ ) {
 		if ( m_ClientSockArray[i] != NULL ) {
 			delete m_ClientSockArray[i];
 			m_ClientSockArray[i] = NULL;
@@ -439,16 +439,16 @@ void CIOCPort::Init(int serversocksize, int clientsocksize, int workernum)
 	}
 
 	m_SockArrayInActive = new CIOCPSocket2* [serversocksize];
-	for(i = 0; i<serversocksize; i++ ) {
+	for(int i = 0; i<serversocksize; i++ ) {
 		m_SockArrayInActive[i] = NULL;
 	}
 
 	m_ClientSockArray = new CIOCPSocket2* [clientsocksize];		// 해당 서버가 클라이언트로서 다른 컴터에 붙는 소켓수
-	for( i=0; i<clientsocksize; i++ ) {
+	for( int i=0; i<clientsocksize; i++ ) {
 		m_ClientSockArray[i] = NULL;
 	}
 
-	for( i = 0; i<serversocksize; i++)
+	for( int i = 0; i<serversocksize; i++)
 		m_SidList.push_back(i);
 
 	InitializeCriticalSection( &g_critical );

--- a/src/server/AIServer/MAP.cpp
+++ b/src/server/AIServer/MAP.cpp
@@ -352,7 +352,7 @@ void MAP::LoadMapTile(HANDLE hFile)
 	}
 
 	int count = 0;
-	for( i = 0; i < m_sizeMap.cy; i++)
+	for( int i = 0; i < m_sizeMap.cy; i++)
 	{
 		for( int j = 0; j < m_sizeMap.cx; j++)
 		{

--- a/src/server/AIServer/MagicProcess.cpp
+++ b/src/server/AIServer/MagicProcess.cpp
@@ -664,11 +664,9 @@ short CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int data1
 
 	int search_x = max_x - min_x + 1;		
 	int search_z = max_z - min_z + 1;	
-	
-	int i, j;
 
-	for(i = 0; i < search_x; i++)	{
-		for(j = 0; j < search_z; j++)	{
+	for(int i = 0; i < search_x; i++)	{
+		for(int j = 0; j < search_z; j++)	{
 			AreaAttackDamage(magictype, min_x+i, min_z+j, magicid, moral, data1, data2, data3, dexpoint, righthand_damage);
 		}
 	}

--- a/src/server/AIServer/N3BASE/N3ShapeMgr.cpp
+++ b/src/server/AIServer/N3BASE/N3ShapeMgr.cpp
@@ -306,7 +306,7 @@ void CN3ShapeMgr::GenerateCollisionData()
 	memset(m_pvCollisions, 0, sizeof(__Vector3) * nFC * 3);
 
 	int nCPC = 0; // Collision Polygon Count
-	for(i = 0; i < iSC; i++) // Shape 에 있는 충돌 메시 만큼 데이터 복사..
+	for(int i = 0; i < iSC; i++) // Shape 에 있는 충돌 메시 만큼 데이터 복사..
 	{
 		CN3VMesh* pVMesh = m_Shapes[i]->CollisionMesh();
 		if (NULL == pVMesh) continue;
@@ -349,7 +349,7 @@ void CN3ShapeMgr::GenerateCollisionData()
 	// 각 선분이 셀에 걸쳐 있는지 혹은 포함되어 있는지 등등 판단해서 인덱스 생성을 한다.
 	int xSMax = (int)(m_fMapWidth / CELL_SUB_SIZE);
 	int zSMax = (int)(m_fMapLength / CELL_SUB_SIZE);
-	for(i = 0; i < nFC; i++)
+	for(int i = 0; i < nFC; i++)
 	{
 		__Vector3 vEdge[3][2];
 
@@ -612,7 +612,6 @@ void CN3ShapeMgr::Tick()
 	int zMainE = (int)((s_CameraData.vEye.z + s_CameraData.fFP) / CELL_MAIN_SIZE); if(zMainE > MAX_CELL_MAIN) zMainE = MAX_CELL_MAIN;
 	
 	__CellMain* pCellCur = NULL;
-	int i = 0, iShp = 0, iSIndex = 0, iSC = m_Shapes.size();;
 	m_ShapesToRender.clear();
 	// 렌더링 리스트 비우고..
 	
@@ -623,11 +622,10 @@ void CN3ShapeMgr::Tick()
 			pCellCur = m_pCells[xM][zM];
 			if(NULL == pCellCur) continue;
 
-			int iSCC = pCellCur->nShapeCount;
-			for(i = 0; i < iSCC; i++)
+			for(int i = 0; i < pCellCur->nShapeCount; i++)
 			{
-				iSIndex = pCellCur->pwShapeIndices[i];
-				__ASSERT(iSIndex >= 0 && iSIndex < iSC, "Shape Index is invalid");
+				int iSIndex = pCellCur->pwShapeIndices[i];
+				__ASSERT(iSIndex >= 0 && iSIndex < m_Shapes.size(), "Shape Index is invalid");
 
 				m_Shapes[iSIndex]->Tick();
 				if(m_Shapes[iSIndex]->m_bDontRender) continue;
@@ -740,7 +738,7 @@ bool CN3ShapeMgr::CheckCollision(	const __Vector3& vPos,		// 충돌 위치
 			if(iSC > 1) qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance); // 카메라 거리에 따라 정렬하고..
 
 			CN3VMesh* pVMesh = NULL;
-			for(i = 0; i < iSC; i++)
+			for(int i = 0; i < iSC; i++)
 			{
 				pVMesh = Shapes[i]->CollisionMesh();
 				if(true == pVMesh->CheckCollision(Shapes[i]->m_Matrix, vPos, vPosNext, pvCol, pvNormal)) return true;
@@ -854,7 +852,7 @@ CN3Shape* CN3ShapeMgr::Pick(int iXScreen, int iYScreen, bool bMustHaveEvent, __V
 	for(int i = 0; it != itEnd; it++, i++) { Shapes[i] = *it; }
 	qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance);
 
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		if(bMustHaveEvent && Shapes[i]->m_iEventID <= 0) continue; // 이벤트가 있어야 한다면...
 		if(Shapes[i]->CheckCollisionPrecisely(vPos, vDir, pvPick) >= 0)

--- a/src/server/AIServer/Npc.cpp
+++ b/src/server/AIServer/Npc.cpp
@@ -301,7 +301,7 @@ void CNpc::InitMagicValuable()
 		m_MagicType4[i].fStartTime = 0.0f;
 	}
 
-	for(i=0; i<MAX_MAGIC_TYPE3; i++)	{
+	for(int i=0; i<MAX_MAGIC_TYPE3; i++)	{
 		m_MagicType3[i].sHPAttackUserID = -1;
 		m_MagicType3[i].sHPAmount = 0;
 		m_MagicType3[i].byHPDuration = 0;
@@ -1536,22 +1536,17 @@ int CNpc::PathFind(CPoint start, CPoint end, float fDistance)
 		return 1;
 	}
 
-
-	int i,j;
-	int min_x, max_x;
-	int min_y, max_y;
-
-	min_x = m_min_x;
-	min_y = m_min_y;
-	max_x = m_max_x;
-	max_y = m_max_y;
+	int min_x = m_min_x;
+	int min_y = m_min_y;
+	int max_x = m_max_x;
+	int max_y = m_max_y;
 
 	m_vMapSize.cx = max_x - min_x + 1;		
 	m_vMapSize.cy = max_y - min_y + 1;
 
-	for(i = 0; i < m_vMapSize.cy; i++)
+	for(int i = 0; i < m_vMapSize.cy; i++)
 	{
-		for(j = 0; j < m_vMapSize.cx; j++)
+		for(int j = 0; j < m_vMapSize.cx; j++)
 		{
 			if((min_x+j) < 0 || (min_y+i) < 0)	return 0;
 			if(m_pOrgMap[min_x + j][min_y + i].m_sEvent == 0 )
@@ -1593,7 +1588,7 @@ int CNpc::PathFind(CPoint start, CPoint end, float fDistance)
 
 	int nAdd = GetDir(m_fStartPoint_X, m_fStartPoint_Y, m_fEndPoint_X, m_fEndPoint_Y);
 
-	for(i=0; i<count; i++)
+	for(int i=0; i<count; i++)
 	{
 		if(i==1)
 		{
@@ -3703,7 +3698,6 @@ int CNpc::GetDefense()
 //	Damage 계산, 만약 m_iHP 가 0 이하이면 사망처리
 BOOL CNpc::SetDamage(int nAttackType, int nDamage, TCHAR *id, int uid, CIOCPort* pIOCP)
 {
-	int i=0, len=0;
 	int userDamage = 0;
 	BOOL bFlag = FALSE;
 	_ExpUserList *tempUser = NULL;
@@ -3736,7 +3730,7 @@ BOOL CNpc::SetDamage(int nAttackType, int nDamage, TCHAR *id, int uid, CIOCPort*
 													// 잉여 데미지는 소용없다.		
 	if( (m_iHP - nDamage) < 0 ) userDamage = m_iHP;
 
-	for(i = 0; i < NPC_HAVE_USER_LIST; i++)	{
+	for(int i = 0; i < NPC_HAVE_USER_LIST; i++)	{
 		if(m_DamagedUserList[i].iUid == uid)	{
 			if(_stricmp("**duration**", id) == 0) {
 				bFlag = TRUE;
@@ -3754,13 +3748,13 @@ BOOL CNpc::SetDamage(int nAttackType, int nDamage, TCHAR *id, int uid, CIOCPort*
 		}
 	}
 
-	for(i = 0; i < NPC_HAVE_USER_LIST; i++)				// 인원 제한이 최종 대미지에 영향을 미치나?
+	for(int i = 0; i < NPC_HAVE_USER_LIST; i++)				// 인원 제한이 최종 대미지에 영향을 미치나?
 	{
 		if(m_DamagedUserList[i].iUid == -1)
 		{
 			if(m_DamagedUserList[i].nDamage <= 0)
 			{
-				len = strlen(id);
+				int len = strlen(id);
 				if( len > MAX_ID_SIZE || len <= 0 ) {
 					TRACE("###  Npc SerDamage Fail ---> uid = %d, name=%s, len=%d, id=%s  ### \n", m_sNid+NPC_BAND, m_strName, len, id);
 					continue;
@@ -3857,7 +3851,6 @@ void CNpc::SendExpToUserList()
 		TRACE("#### Npc-SendExpToUserList() ZoneIndex Fail : [name=%s], zoneindex=%d #####\n", m_strName, m_ZoneIndex);
 		return;
 	}
-	int i=0;
 	int nExp = 0;
 	int nPartyExp = 0;
 	int nLoyalty = 0;
@@ -3877,7 +3870,7 @@ void CNpc::SendExpToUserList()
 
 	IsUserInSight();	// 시야권내에 있는 유저 셋팅..
 				
-	for(i = 0; i < NPC_HAVE_USER_LIST; i++)				// 일단 리스트를 검색한다.
+	for(int i = 0; i < NPC_HAVE_USER_LIST; i++)				// 일단 리스트를 검색한다.
 	{
 		if(m_DamagedUserList[i].iUid < 0 || m_DamagedUserList[i].nDamage<= 0) continue;
 		if(m_DamagedUserList[i].bIs == TRUE) pUser = m_pMain->GetUserPtr(m_DamagedUserList[i].iUid);
@@ -4204,22 +4197,22 @@ int CNpc::FindFriend(int type)
 	int search_x = max_x - min_x + 1;		
 	int search_z = max_z - min_z + 1;	
 	
-	int i, j, count = 0;
+	int count = 0; // TODO: Check if this is a bug, since we don't increment it for target healer.
 	_TargetHealer arHealer[9];
-	for(i=0; i<9; i++)	{
+	for(int i=0; i<9; i++)	{
 		arHealer[i].sNID = -1;
 		arHealer[i].sValue = 0;
 	}
 
-	for(i = 0; i < search_x; i++)	{
-		for(j = 0; j < search_z; j++)	{
+	for(int i = 0; i < search_x; i++)	{
+		for(int j = 0; j < search_z; j++)	{
 			FindFriendRegion(min_x+i, min_z+j, pMap, &arHealer[count], type);
 			//FindFriendRegion(min_x+i, min_z+j, pMap, type);
 		}
 	}
 
 	int iValue = 0, iMonsterNid = 0;
-	for(i=0; i<9; i++)	{
+	for(int i=0; i<9; i++)	{
 		if(iValue < arHealer[i].sValue)	{
 			iValue = arHealer[i].sValue;
 			iMonsterNid = arHealer[i].sNID;
@@ -4636,10 +4629,9 @@ BOOL CNpc::GetUserInView()
 	int search_z = max_z - min_z + 1;	
 	
 	BOOL bFlag = FALSE;
-	int i, j;
 
-	for(i = 0; i < search_x; i++)	{
-		for(j = 0; j < search_z; j++)	{
+	for(int i = 0; i < search_x; i++)	{
+		for(int j = 0; j < search_z; j++)	{
 			bFlag = GetUserInViewRange(min_x+i, min_z+j);
 			if(bFlag == TRUE)	return TRUE;
 		}
@@ -4751,18 +4743,17 @@ void CNpc::IsUserInSight()
 	// Npc와 User와의 거리가 50미터 안에 있는 사람에게만,, 경험치를 준다..
 	int iSearchRange = NPC_EXP_RANGE;		
 
-	int i,j;
 	__Vector3 vStart, vEnd;
 	float fDis = 0.0f;
 
 	vStart.Set(m_fCurX, m_fCurY, m_fCurZ);
 
-	for(j = 0; j < NPC_HAVE_USER_LIST; j++)
+	for(int j = 0; j < NPC_HAVE_USER_LIST; j++)
 	{
 		m_DamagedUserList[j].bIs = FALSE;
 	}
 
-	for(i = 0; i < NPC_HAVE_USER_LIST; i++)
+	for(int i = 0; i < NPC_HAVE_USER_LIST; i++)
 	{
 		pUser = m_pMain->GetUserPtr(m_DamagedUserList[i].iUid);
 		if(pUser == NULL)	continue;
@@ -5248,7 +5239,7 @@ void CNpc::GiveNpcHaveItem(CIOCPort* pIOCP)
 	int temp = 0;
 	int iPer = 0, iMakeItemCode = 0, iMoney = 0;
 	int iRandom;
-	int nCount = 1, i =0;
+	int nCount = 1;
 	CString string;
 
 /*	if( m_byMoneyType == 1 )	{
@@ -5277,7 +5268,7 @@ void CNpc::GiveNpcHaveItem(CIOCPort* pIOCP)
 	}
 	
 
-	for(i = 0; i < m_pMain->m_NpcItem.m_nRow; i++)	{
+	for(int i = 0; i < m_pMain->m_NpcItem.m_nRow; i++)	{
 		if(m_pMain->m_NpcItem.m_ppItem[i][0] != m_iItem) continue;
 		for(int j=1; j<m_pMain->m_NpcItem.m_nField; j+=2)	{
 			if(m_pMain->m_NpcItem.m_ppItem[i][j] == 0) continue;
@@ -5319,7 +5310,7 @@ void CNpc::GiveNpcHaveItem(CIOCPort* pIOCP)
 	Setfloat(pBuf, m_fCurZ, index);
 	Setfloat(pBuf, m_fCurY, index);
 	SetByte(pBuf, nCount, index);
-	for(i=0; i<nCount; i++)	{
+	for(int i=0; i<nCount; i++)	{
 		SetInt(pBuf, m_GiveItemList[i].sSid, index);
 		SetShort(pBuf, m_GiveItemList[i].count, index);
 
@@ -5369,10 +5360,9 @@ __Vector3 CNpc::ComputeDestPos( __Vector3 vCur, float fDegree, float fDegreeOffs
 
 int	CNpc::GetPartyDamage(int iNumber)
 {
-	int i=0;
 	int nDamage = 0;
 	CUser* pUser = NULL;
-	for(i = 0; i < NPC_HAVE_USER_LIST; i++)				// 일단 리스트를 검색한다.
+	for(int i = 0; i < NPC_HAVE_USER_LIST; i++)				// 일단 리스트를 검색한다.
 	{
 		if(m_DamagedUserList[i].iUid < 0 || m_DamagedUserList[i].nDamage<= 0) continue;
 		if(m_DamagedUserList[i].bIs == TRUE) pUser = m_pMain->GetUserPtr(m_DamagedUserList[i].iUid);
@@ -5669,7 +5659,7 @@ int	CNpc::ItemProdution(int item_number)							// 아이템 제작
 
 int  CNpc::GetItemGrade(int item_grade)
 {
-	int iPercent = 0, iRandom = 0, i=0;
+	int iPercent = 0, iRandom = 0;
 	int iItemGrade[9];
 	_MAKE_ITEM_GRADE_CODE* pItemData = NULL;
 
@@ -5683,7 +5673,7 @@ int  CNpc::GetItemGrade(int item_grade)
 	iItemGrade[6] = pItemData->sGrade_7;	iItemGrade[7] = pItemData->sGrade_8;
 	iItemGrade[8] = pItemData->sGrade_9;	
 	
-	for(i=0; i<9; i++)	{
+	for(int i=0; i<9; i++)	{
 		if(i == 0)	{
 			if(iItemGrade[i] == 0)	{
 				iPercent += iItemGrade[i];
@@ -5715,7 +5705,7 @@ int  CNpc::GetItemGrade(int item_grade)
 
 int  CNpc::GetWeaponItemCodeNumber(int item_type)
 {
-	int iPercent = 0, iRandom = 0, i=0, iItem_level = 0;
+	int iPercent = 0, iRandom = 0, iItem_level = 0;
 	_MAKE_WEAPON* pItemData = NULL;
 
 	iRandom = myrand(0, 1000);
@@ -5730,7 +5720,7 @@ int  CNpc::GetWeaponItemCodeNumber(int item_type)
 
 	if(pItemData == NULL)	return 0;
 
-	for(i=0; i<MAX_UPGRADE_WEAPON; i++)	{
+	for(int i=0; i<MAX_UPGRADE_WEAPON; i++)	{
 		if(i == 0)	{
 			if(pItemData->sClass[i] == 0)	{
 				iPercent += pItemData->sClass[i];
@@ -5761,7 +5751,7 @@ int  CNpc::GetWeaponItemCodeNumber(int item_type)
 
 int  CNpc::GetItemCodeNumber(int level, int item_type)
 {
-	int iItemCode = 0, iRandom = 0, i=0, iItemType = 0, iPercent = 0;
+	int iItemCode = 0, iRandom = 0, iItemType = 0, iPercent = 0;
 	int iItemPercent[3];
 	_MAKE_ITEM_LARE_CODE* pItemData = NULL;
 
@@ -5772,7 +5762,7 @@ int  CNpc::GetItemCodeNumber(int level, int item_type)
 	iItemPercent[1] = pItemData->sMagicItem;
 	iItemPercent[2] = pItemData->sGereralItem;
 
-	for(i=0; i<3; i++)	{
+	for(int i=0; i<3; i++)	{
 		if(i == 0)	{
 			if( COMPARE( iRandom, 0, iItemPercent[i]) )	{
 				iItemType = i+1;

--- a/src/server/AIServer/NpcThread.cpp
+++ b/src/server/AIServer/NpcThread.cpp
@@ -29,7 +29,6 @@ UINT NpcThreadProc(LPVOID pParam /* NPC_THREAD_INFO ptr */)
 	CIOCPort*			pIOCP	= NULL;
 	CPoint				pt;
 
-	int					i			= 0;
 	DWORD				dwDiffTime	= 0;
 	DWORD				dwSleep		= 250;
 	DWORD				dwTickTime  = 0;
@@ -46,7 +45,7 @@ UINT NpcThreadProc(LPVOID pParam /* NPC_THREAD_INFO ptr */)
 	{
 		fTime2 = TimeGet();
 
-		for(i = 0; i < NPC_NUM; i++)
+		for(int i = 0; i < NPC_NUM; i++)
 		{
 			pNpc = pInfo->pNpc[i];
 			pIOCP = pInfo->pIOCP;
@@ -153,17 +152,16 @@ UINT ZoneEventThreadProc(LPVOID pParam /* = NULL */)
 	float  fCurrentTime = 0.0f;
 	MAP* pMap = NULL;
 	CRoomEvent* pRoom = NULL ;
-	int i=0, j=0;
 
 	while(!g_bNpcExit)
 	{
 		fCurrentTime = TimeGet();
-		for( i=0; i<m_pMain->g_arZone.size(); i++)	{
+		for( int i=0; i<m_pMain->g_arZone.size(); i++)	{
 			pMap = m_pMain->g_arZone[i];
 			if( !pMap ) continue;
 			if( pMap->m_byRoomEvent == 0 ) continue;		// 현재의 존이 던젼담당하는 존이 아니면 리턴..
 			if( pMap->IsRoomStatusCheck() == TRUE )	continue;	// 전체방이 클리어 되었다면
-			for( j=1; j<pMap->m_arRoomEventArray.GetSize()+1; j++)	{	// 방번호는 1번부터 시작
+			for( int j=1; j<pMap->m_arRoomEventArray.GetSize()+1; j++)	{	// 방번호는 1번부터 시작
 				pRoom = pMap->m_arRoomEventArray.GetData( j );
 				if( !pRoom ) continue;
 				if( pRoom->m_byStatus == 1 || pRoom->m_byStatus == 3 )   continue; // 1:init, 2:progress, 3:clear

--- a/src/server/AIServer/Server/MAP.cpp
+++ b/src/server/AIServer/Server/MAP.cpp
@@ -50,8 +50,6 @@ MAP::~MAP()
 
 void MAP::RemoveMapData()
 {
-//	int i, j, k;
-
 	if( m_ppRegion ) {
 		for(int i=0; i< m_sizeRegion.cx; i++) {
 			delete[] m_ppRegion[i];
@@ -342,7 +340,7 @@ void MAP::LoadMapTile(HANDLE hFile)
 	}
 
 	int count = 0;
-	for( i = 0; i < m_sizeMap.cy; i++)
+	for(int i = 0; i < m_sizeMap.cy; i++)
 	{
 		for( int j = 0; j < m_sizeMap.cx; j++)
 		{

--- a/src/server/AIServer/ServerDlg.cpp
+++ b/src/server/AIServer/ServerDlg.cpp
@@ -189,7 +189,7 @@ BOOL CServerDlg::OnInitDialog()
 	m_byTestMode = NOW_TEST_MODE;
 
 	// User Point Init
-	for(i=0; i<MAX_USER; i++)
+	for(int i=0; i<MAX_USER; i++)
 		m_pUser[i] = NULL;
 
 	// Server Start
@@ -235,7 +235,7 @@ BOOL CServerDlg::OnInitDialog()
 	//----------------------------------------------------------------------
 	m_Iocport.Init(MAX_SOCKET,1, 1);
 
-	for(i=0; i<MAX_SOCKET; i++) {
+	for(int i=0; i<MAX_SOCKET; i++) {
 		m_Iocport.m_SockArrayInActive[i] = new CGameSocket;
 	}
 
@@ -644,7 +644,6 @@ BOOL CServerDlg::GetNpcItemTable()
 {
 	CNpcItemSet NpcItemSet;
 	int nRowCount = 0;
-	short i;
 	int nItem = 0;
 
 	try
@@ -677,14 +676,14 @@ BOOL CServerDlg::GetNpcItemTable()
 		if(nRowCount == 0) return FALSE;
 
 		m_NpcItem.m_ppItem = new int* [m_NpcItem.m_nRow];
-		for(i = 0; i < m_NpcItem.m_nRow; i++)
+		for(int i = 0; i < m_NpcItem.m_nRow; i++)
 		{
 			m_NpcItem.m_ppItem[i] = new int[m_NpcItem.m_nField];
 		}
 
 		NpcItemSet.MoveFirst();
 
-		i = 0;
+		int i = 0;
 		while(!NpcItemSet.IsEOF())
 		{
 			m_NpcItem.m_ppItem[i][0] = NpcItemSet.m_sIndex;
@@ -952,7 +951,6 @@ BOOL CServerDlg::CreateNpcThread()
 	int		nSerial		= m_sMapEventNpc;
 	int		nPathSerial = 1;
 	int		nNpcCount	= 0;
-	int		i=0, j=0;
 	int nRandom = 0, nServerNum = 0;
 	double  dbSpeed = 0;
 
@@ -1003,7 +1001,7 @@ BOOL CServerDlg::CreateNpcThread()
 			nServerNum = GetServerNumber( NpcPosSet.m_ZoneID );
 
 			if( m_byZone == nServerNum || m_byZone == UNIFY_ZONE)	{
-				for(j=0; j<nMonsterNumber; j++)		{
+				for(int j=0; j<nMonsterNumber; j++)		{
 					CNpc*		pNpc		= new CNpc;
 					pNpc->m_sNid	= nSerial++;			// 서버 내에서의 고유 번호
 					pNpc->m_sSid	= (short)NpcPosSet.m_NpcID;		// MONSTER(NPC) Serial ID
@@ -1180,7 +1178,7 @@ BOOL CServerDlg::CreateNpcThread()
 			
 					pNpc->m_ZoneIndex		= -1;
 
-					for(i = 0; i < g_arZone.size(); i++)	{
+					for(int i = 0; i < g_arZone.size(); i++)	{
 						if(g_arZone[i]->m_nZoneNumber == pNpc->m_sCurZone)	{
 							pNpc->m_ZoneIndex = i;
 							break;
@@ -1255,7 +1253,7 @@ BOOL CServerDlg::CreateNpcThread()
 	int nThreadNumber = 0;
 	CNpcThread* pNpcThread = NULL;
 
-	for(i = 0; i < m_arNpc.GetSize(); i++)
+	for(int i = 0; i < m_arNpc.GetSize(); i++)
 	{
 		if( step == 0 )
 		{
@@ -1291,7 +1289,7 @@ BOOL CServerDlg::CreateNpcThread()
 	pNpcThread->pIOCP = &m_Iocport;
 	pNpcThread->m_sThreadNumber = 1000;
 
-	for(i = 0; i < NPC_NUM; i++) // 미리 최대 소환 NPC_NUM마리 메모리 할당
+	for(int i = 0; i < NPC_NUM; i++) // 미리 최대 소환 NPC_NUM마리 메모리 할당
 	{
 		CNpc*	pNpc = new CNpc;
 		pNpc->m_sNid = nSerial++;
@@ -1322,11 +1320,9 @@ BOOL CServerDlg::CreateNpcThread()
 //	NPC Thread 들을 작동시킨다.
 void CServerDlg::ResumeAI()
 {
-	int i, j;
-
-	for(i = 0; i < m_arNpcThread.size(); i++)
+	for(int i = 0; i < m_arNpcThread.size(); i++)
 	{
-		for(j = 0; j < NPC_NUM; j++)
+		for(int j = 0; j < NPC_NUM; j++)
 		{
 			m_arNpcThread[i]->m_ThreadInfo.pNpc[j] = m_arNpcThread[i]->m_pNpc[j];
 		}
@@ -1339,7 +1335,7 @@ void CServerDlg::ResumeAI()
 
 	// Event Npc Logic
 /*	m_arEventNpcThread[0]->m_ThreadInfo.hWndMsg = this->GetSafeHwnd();
-	for(j = 0; j < NPC_NUM; j++)
+	for(int j = 0; j < NPC_NUM; j++)
 	{
 		m_arEventNpcThread[0]->m_ThreadInfo.pNpc[j] = NULL;	// 초기 소환 몹이 당연히 없으므로 NULL로 작동을 안시킴
 		m_arEventNpcThread[0]->m_ThreadInfo.m_byNpcUsed[j] = 0;
@@ -1363,16 +1359,14 @@ BOOL CServerDlg::DestroyWindow()
 
 	if(m_UserLogFile.m_hFile != CFile::hFileNull) m_UserLogFile.Close();
 	if(m_ItemLogFile.m_hFile != CFile::hFileNull) m_ItemLogFile.Close();
-	
-	int i=0;
 
-	for(i = 0; i < m_arNpcThread.size(); i++)
+	for(int i = 0; i < m_arNpcThread.size(); i++)
 	{
 		WaitForSingleObject(m_arNpcThread[i]->m_pThread->m_hThread, INFINITE);
 	}
 
 	// Event Npc Logic
-/*	for(i = 0; i < m_arEventNpcThread.size(); i++)
+/*	for(int i = 0; i < m_arEventNpcThread.size(); i++)
 	{
 		WaitForSingleObject(m_arEventNpcThread[i]->m_pThread->m_hThread, INFINITE);
 	}	*/
@@ -1382,7 +1376,7 @@ BOOL CServerDlg::DestroyWindow()
 	// DB테이블 삭제 부분
 
 	// Map(Zone) Array Delete...
-	for( i=0; i<g_arZone.size(); i++ )
+	for( int i=0; i<g_arZone.size(); i++ )
 		delete g_arZone[i];
 	g_arZone.clear();
 
@@ -1395,13 +1389,13 @@ BOOL CServerDlg::DestroyWindow()
 		m_arNpcTable.DeleteAllData();
 	
 	// NpcThread Array Delete
-	for(i = 0; i < m_arNpcThread.size(); i++)
+	for(int i = 0; i < m_arNpcThread.size(); i++)
 		delete m_arNpcThread[i];
 	m_arNpcThread.clear();
 
 	// Event Npc Logic
 	// EventNpcThread Array Delete
-/*	for(i = 0; i < m_arEventNpcThread.size(); i++)
+/*	for(int i = 0; i < m_arEventNpcThread.size(); i++)
 		delete m_arEventNpcThread[i];
 	m_arEventNpcThread.clear();		*/
 
@@ -1448,7 +1442,7 @@ BOOL CServerDlg::DestroyWindow()
 		m_arNpc.DeleteAllData();
 
 	// User Array Delete
-	for(i = 0; i < MAX_USER; i++)	{
+	for(int i = 0; i < MAX_USER; i++)	{
 		if(m_pUser[i])	{
 			delete m_pUser[i];
 			m_pUser[i] = NULL;
@@ -1574,14 +1568,14 @@ void CServerDlg::AllNpcInfo()
 	// server alive check
 	CNpc* pNpc = NULL;
 	MAP* pMap = NULL;
-	int nZone = 0, i=0;
+	int nZone = 0;
 	int size = m_arNpc.GetSize();
 
 	int send_index = 0, zone_index = 0, packet_size = 0;
 	int count = 0, send_count = 0, send_tot = 0;
 	char send_buff[2048];		::ZeroMemory(send_buff, sizeof(send_buff));
 
-	for(i=0; i<m_sTotalMap; i++)	{
+	for(int i=0; i<m_sTotalMap; i++)	{
 		pMap = g_arZone[i];
 		if(pMap == NULL)	continue;
 		nZone = pMap->m_nZoneNumber;
@@ -1741,17 +1735,16 @@ void CServerDlg::DeleteAllUserList(int zone)
 	if(zone == 9999 && m_bFirstServerFlag == TRUE)	{						// 모든 소켓이 끊어진 상태...
 		CUser* pUser = NULL;
 		MAP* pMap = NULL;
-		int i=0;
 
 		TRACE("*** DeleteAllUserList - Start *** \n");
 
-		for(i=0; i<m_sTotalMap; i++)	{
+		for(int i=0; i<m_sTotalMap; i++)	{
 			pMap = g_arZone[i];
 			if(pMap == NULL)	continue;
-			for( i=0; i<pMap->m_sizeRegion.cx; i++ ) {
+			for( int k=0; k<pMap->m_sizeRegion.cx; k++ ) {
 				for( int j=0; j<pMap->m_sizeRegion.cy; j++ ) {
-					if( !pMap->m_ppRegion[i][j].m_RegionUserArray.IsEmpty() )
-						pMap->m_ppRegion[i][j].m_RegionUserArray.DeleteAllData();
+					if( !pMap->m_ppRegion[k][j].m_RegionUserArray.IsEmpty() )
+						pMap->m_ppRegion[k][j].m_RegionUserArray.DeleteAllData();
 				}
 			}
 		}
@@ -1760,7 +1753,7 @@ void CServerDlg::DeleteAllUserList(int zone)
 
 		EnterCriticalSection( &g_User_critical );
 		// User Array Delete
-		for(i = 0; i < MAX_USER; i++)	{
+		for(int i = 0; i < MAX_USER; i++)	{
 			pUser = m_pUser[i];
 			if(pUser == NULL)  continue;
 			delete m_pUser[i];
@@ -1949,7 +1942,7 @@ void CServerDlg::SyncTest()
 /*
 	fprintf(stream, "*****   User List  *****\n");
 
-	for(i=0; i<MAX_USER; i++)	{
+	for(int i=0; i<MAX_USER; i++)	{
 		//pUser = m_ppUserActive[i];
 		pUser = m_pUser[i];
 		if(pUser == NULL)		continue;
@@ -1957,17 +1950,14 @@ void CServerDlg::SyncTest()
 	}	
 
 	fprintf(stream, "*****   Region List  *****\n");
-	int k=0, total_user = 0, total_mon=0;
-	MAP* pMap = NULL;
-
-	for(k=0; k<m_sTotalMap; k++)	{
-		pMap = g_arZone[k];
+	for(int k=0; k<m_sTotalMap; k++)	{
+		MAP* pMap = g_arZone[k];
 		if(pMap == NULL)	continue;
-		for( i=0; i<pMap->m_sizeRegion.cx; i++ ) {
+		for( int i=0; i<pMap->m_sizeRegion.cx; i++ ) {
 			for( int j=0; j<pMap->m_sizeRegion.cy; j++ ) {
 				EnterCriticalSection( &g_User_critical );
-				total_user = pMap->m_ppRegion[i][j].m_RegionUserArray.GetSize();
-				total_mon = pMap->m_ppRegion[i][j].m_RegionNpcArray.GetSize();
+				int total_user = pMap->m_ppRegion[i][j].m_RegionUserArray.GetSize();
+				int total_mon = pMap->m_ppRegion[i][j].m_RegionNpcArray.GetSize();
 				LeaveCriticalSection( &g_User_critical );
 
 				if(total_user > 0 || total_mon > 0)	{
@@ -2176,7 +2166,7 @@ BOOL CServerDlg::SetSummonNpcData(CNpc* pNpc, int zone, float fx, float fz)
 
 	int test = 0;
 	
-	for(i = 0; i < NPC_NUM; i++ ) {
+	for(int i = 0; i < NPC_NUM; i++ ) {
 		test = m_arEventNpcThread[0]->m_ThreadInfo.m_byNpcUsed[i];
 		TRACE("setsummon == %d, used=%d\n", i, test);
 		if( m_arEventNpcThread[0]->m_ThreadInfo.m_byNpcUsed[i] == 0 )	{
@@ -2391,16 +2381,13 @@ BOOL CServerDlg::GetMagicType4Data()
 
 void CServerDlg::RegionCheck()
 {
-	int i=0,k=0, total_user = 0;
-	MAP* pMap = NULL;
-
-	for(k=0; k<m_sTotalMap; k++)	{
-		pMap = g_arZone[k];
+	for(int k=0; k<m_sTotalMap; k++)	{
+		MAP* pMap = g_arZone[k];
 		if(pMap == NULL)	continue;
-		for( i=0; i<pMap->m_sizeRegion.cx; i++ ) {
+		for( int i=0; i<pMap->m_sizeRegion.cx; i++ ) {
 			for( int j=0; j<pMap->m_sizeRegion.cy; j++ ) {
 				EnterCriticalSection( &g_User_critical );
-				total_user = pMap->m_ppRegion[i][j].m_RegionUserArray.GetSize();
+				int total_user = pMap->m_ppRegion[i][j].m_RegionUserArray.GetSize();
 				LeaveCriticalSection( &g_User_critical );
 				if( total_user > 0 )  	pMap->m_ppRegion[i][j].m_byMoving = 1;
 				else	pMap->m_ppRegion[i][j].m_byMoving = 0; 
@@ -2411,19 +2398,15 @@ void CServerDlg::RegionCheck()
 
 BOOL CServerDlg::AddObjectEventNpc(_OBJECT_EVENT* pEvent, int zone_number)
 {
-	int i=0, j=0, objectid=0;
-	CNpcTable*	pNpcTable = NULL;
-	BOOL bFindNpcTable = FALSE;
-	int offset = 0;
-	int nServerNum = 0;
-	nServerNum = GetServerNumber( zone_number );
+	int nServerNum = GetServerNumber( zone_number );
 	//if(m_byZone != zone_number)	 return FALSE;
 	//if(m_byZone != UNIFY_ZONE)	{
 	//	if(m_byZone != nServerNum)	 return FALSE;
 	//}
 
 	//if( zone_number > 201 )	return FALSE;	// test
-	pNpcTable = m_arNpcTable.GetData(pEvent->sIndex);
+	CNpcTable* pNpcTable = m_arNpcTable.GetData(pEvent->sIndex);
+	BOOL bFindNpcTable = FALSE;
 	if(pNpcTable == NULL)	{
 		bFindNpcTable = FALSE;
 		TRACE("#### AddObjectEventNpc Fail : [sid = %d], zone=%d #####\n", pEvent->sIndex, zone_number);
@@ -2605,12 +2588,8 @@ void CServerDlg::SendSystemMsg( char* pMsg, int zone, int type, int who )
 void CServerDlg::ResetBattleZone()
 {
 	TRACE("ServerDlg - ResetBattleZone() : start \n");
-	MAP* pMap = NULL;
-	CRoomEvent* pRoom = NULL ;
-	int i=0, j=0;
-
-	for( i=0; i<g_arZone.size(); i++)	{
-		pMap = g_arZone[i];
+	for(int i=0; i<g_arZone.size(); i++)	{
+		MAP* pMap = g_arZone[i];
 		if( !pMap ) continue;
 		if( pMap->m_byRoomEvent == 0 ) continue;		// 현재의 존이 던젼담당하는 존이 아니면 리턴..
 		//if( pMap->IsRoomStatusCheck() == TRUE )	continue;	// 전체방이 클리어 되었다면

--- a/src/server/AIServer/User.cpp
+++ b/src/server/AIServer/User.cpp
@@ -1020,10 +1020,8 @@ void CUser::HealMagic()
 	int search_x = max_x - min_x + 1;		
 	int search_z = max_z - min_z + 1;	
 	
-	int i, j;
-
-	for(i = 0; i < search_x; i++)	{
-		for(j = 0; j < search_z; j++)	{
+	for(int i = 0; i < search_x; i++)	{
+		for(int j = 0; j < search_z; j++)	{
 			HealAreaCheck( min_x+i, min_z+j );
 		}
 	}

--- a/src/server/Aujard/Aujard.vcxproj
+++ b/src/server/Aujard/Aujard.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -94,7 +93,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/server/Aujard/DBAgent.cpp
+++ b/src/server/Aujard/DBAgent.cpp
@@ -145,12 +145,12 @@ void CDBAgent::MUserInit(int uid)
 	// Ω∫≈≥ √ ±‚»≠
 	for(int i=0; i<9; i++) pUser->m_bstrSkill[i] = 0;
 
-	for(i = 0; i < SLOT_MAX+HAVE_MAX; i++) {// ¬¯øÎ∞πºˆ + º“¿Ø∞πºˆ(14+28=42)
+	for(int i = 0; i < SLOT_MAX+HAVE_MAX; i++) {// ¬¯øÎ∞πºˆ + º“¿Ø∞πºˆ(14+28=42)
 		pUser->m_sItemArray[i].nNum = 0;
 		pUser->m_sItemArray[i].sDuration = 0;
 		pUser->m_sItemArray[i].sCount = 0;
 	}
-	for(i = 0; i < WAREHOUSE_MAX; i++) {
+	for(int i = 0; i < WAREHOUSE_MAX; i++) {
 		pUser->m_sWarehouseArray[i].nNum = 0;
 		pUser->m_sWarehouseArray[i].sDuration = 0;
 		pUser->m_sWarehouseArray[i].sCount = 0;
@@ -373,7 +373,7 @@ BOOL CDBAgent::LoadUserData(char *userid, int uid)
 	__int64 serial = 0;
 	_ITEM_TABLE* pTable = NULL;
 
-	for(i = 0; i < HAVE_MAX+SLOT_MAX; i++)        // ¬¯øÎ∞πºˆ + º“¿Ø∞πºˆ(14+28=42)
+	for(int i = 0; i < HAVE_MAX+SLOT_MAX; i++)        // ¬¯øÎ∞πºˆ + º“¿Ø∞πºˆ(14+28=42)
 	{ 
 		itemid = GetDWORD(strItem, index);
 		duration = GetShort(strItem, index );
@@ -510,7 +510,7 @@ int CDBAgent::UpdateUser(const char *userid, int uid, int type )
 		SetByte(strSkill, pUser->m_bstrSkill[i], index);
 
 	index = 0;
-	for(i = 0; i < HAVE_MAX+SLOT_MAX; i++) // ¬¯øÎ∞πºˆ + º“¿Ø∞πºˆ(14+28=42)
+	for(int i = 0; i < HAVE_MAX+SLOT_MAX; i++) // ¬¯øÎ∞πºˆ + º“¿Ø∞πºˆ(14+28=42)
 	{ 
 		if( pUser->m_sItemArray[i].nNum > 0 ) {
 			if( m_pMain->m_ItemtableArray.GetData(pUser->m_sItemArray[i].nNum) == FALSE )

--- a/src/server/Ebenezer/AISocket.cpp
+++ b/src/server/Ebenezer/AISocket.cpp
@@ -1003,7 +1003,7 @@ void CAISocket::RecvNpcGiveItem(char* pBuf)
 		return;
 
 	pItem = new _ZONE_ITEM;
-	for(i=0; i<6; i++) {
+	for(int i=0; i<6; i++) {
 		pItem->itemid[i] = 0;
 		pItem->count[i] = 0;
 	}
@@ -1012,7 +1012,7 @@ void CAISocket::RecvNpcGiveItem(char* pBuf)
 	pItem->x = fX;
 	pItem->z = fZ;
 	pItem->y = fY;
-	for(i=0; i<byCount; i++) {
+	for(int i=0; i<byCount; i++) {
 		if( m_pMain->m_ItemtableArray.GetData(nItemNumber[i]) ) {
 			pItem->itemid[i] = nItemNumber[i];
 			pItem->count[i] = sCount[i];

--- a/src/server/Ebenezer/Ebenezer.vcxproj
+++ b/src/server/Ebenezer/Ebenezer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -97,7 +96,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/server/Ebenezer/EbenezerDlg.cpp
+++ b/src/server/Ebenezer/EbenezerDlg.cpp
@@ -546,8 +546,6 @@ BOOL CEbenezerDlg::DestroyWindow()
 	KillTimer( MARKET_BBS_TIME );
 	KillTimer( PACKET_CHECK );
 
-	int i=0;
-
 	if( m_hReadQueueThread )
 		::TerminateThread( m_hReadQueueThread, 0 );
 
@@ -611,11 +609,11 @@ BOOL CEbenezerDlg::DestroyWindow()
 	if ( !m_HomeArray.IsEmpty() )
 		m_HomeArray.DeleteAllData();
 
-	for( i=0; i<m_ZoneArray.size(); i++ )
+	for( int i=0; i<m_ZoneArray.size(); i++ )
 		delete m_ZoneArray[i];
 	m_ZoneArray.clear();
 	
-	for( i=0; i<m_LevelUpArray.size(); i++)
+	for( int i=0; i<m_LevelUpArray.size(); i++)
 		delete m_LevelUpArray[i];
 	m_LevelUpArray.clear();
 
@@ -1580,7 +1578,7 @@ BOOL CEbenezerDlg::LoadLevelUpTable()
 
 void CEbenezerDlg::GetTimeFromIni()
 {
-	int year=0, month=0, date=0, hour=0, server_count=0, sgroup_count = 0, i=0;
+	int year=0, month=0, date=0, hour=0, server_count=0, sgroup_count = 0;
 	char ipkey[20]; memset( ipkey, 0x00, 20 );
 
 	m_Ini.SetPath("server.ini");
@@ -1604,7 +1602,7 @@ void CEbenezerDlg::GetTimeFromIni()
 		return;
 	}
 
-	for( i=0; i<server_count; i++ ) {
+	for( int i=0; i<server_count; i++ ) {
 		_ZONE_SERVERINFO *pInfo = new _ZONE_SERVERINFO;
 		sprintf( ipkey, "SERVER_%02d", i );
 		pInfo->sServerNo = m_Ini.GetProfileInt("ZONE_INFO", ipkey, 1);
@@ -1622,7 +1620,7 @@ void CEbenezerDlg::GetTimeFromIni()
 			AfxMessageBox("ServerCount Error!!");
 			return;
 		}
-		for( i=0; i<sgroup_count; i++ ) {
+		for( int i=0; i<sgroup_count; i++ ) {
 			_ZONE_SERVERINFO *pInfo = new _ZONE_SERVERINFO;
 			sprintf( ipkey, "GSERVER_%02d", i );
 			pInfo->sServerNo = m_Ini.GetProfileInt("SG_INFO", ipkey, 1);
@@ -2540,9 +2538,9 @@ void CEbenezerDlg::SyncTest(int nType)
 	int iErrorCode = 0, send_index = 0;
 
 	SetByte(pBuf, AG_CHECK_ALIVE_REQ, len);
-	int i=0, k=0, total_user = 0, total_mon=0;
+	int total_user = 0, total_mon=0;
 
-	for(i=0; i<m_ZoneArray.size(); i++) {
+	for(int i=0; i<m_ZoneArray.size(); i++) {
 			pSocket = m_AISocketArray.GetData( m_ZoneArray[i]->m_nZoneNumber );
 			if( !pSocket )		continue;	
 			else {
@@ -2571,11 +2569,11 @@ void CEbenezerDlg::SyncTest(int nType)
 	
 	C3DMap* pMap = NULL;
 
-	for(k=0; k<m_ZoneArray.size(); k++)	{
+	for(int k=0; k<m_ZoneArray.size(); k++)	{
 		//if( k != 2 ) continue;		// 201 존만 체크..
 		pMap = m_ZoneArray[k];
 		if(pMap == NULL)	continue;
-		for( i=0; i<pMap->GetXRegionMax(); i++ ) {
+		for( int i=0; i<pMap->GetXRegionMax(); i++ ) {
 			for( int j=0; j<pMap->GetZRegionMax(); j++ ) {
 				EnterCriticalSection( &g_region_critical );
 				total_user = pMap->m_ppRegion[i][j].m_RegionUserArray.GetSize();
@@ -2694,7 +2692,7 @@ void CEbenezerDlg::SendAllUserInfo()
 	
 	EnterCriticalSection( &g_region_critical );
 
-	for(i=0; i<m_PartyArray.GetSize(); i++)	{
+	for(int i=0; i<m_PartyArray.GetSize(); i++)	{
 		pParty = m_PartyArray.GetData( i );
 		if( !pParty ) return;
 		send_index = 0;
@@ -2777,14 +2775,13 @@ void CEbenezerDlg::DeleteAllNpcList(int flag)
 
 	CUser* pUser = NULL;
 	C3DMap* pMap = NULL;
-	int i=0;
 
 	// region Npc Array Delete
-	for(i=0; i<m_ZoneArray.size(); i++)	{
+	for(int i=0; i<m_ZoneArray.size(); i++)	{
 		pMap = (C3DMap*)m_ZoneArray[i];
 		if( !pMap )	continue;
 
-		for( i=0; i<pMap->GetXRegionMax(); i++ ) {
+		for( i=0; i<pMap->GetXRegionMax(); i++ ) { // TODO: Check if this is not a bug that resets parent loop.
 			for( int j=0; j<pMap->GetZRegionMax(); j++ ) {
 				if( !pMap->m_ppRegion[i][j].m_RegionNpcArray.IsEmpty() )
 					pMap->m_ppRegion[i][j].m_RegionNpcArray.DeleteAllData();
@@ -3226,7 +3223,6 @@ BOOL CEbenezerDlg::LoadAllKnights()
 {
 	CKnightsSet	KnightsSet;
 	CString strKnightsName, strChief, strViceChief_1, strViceChief_2, strViceChief_3;
-	int i=0;
 
 	if( !KnightsSet.Open() ) {
 		AfxMessageBox(_T("Knights Open Fail!"));
@@ -3271,7 +3267,7 @@ BOOL CEbenezerDlg::LoadAllKnights()
 				pKnights->bGrade = GetKnightsGrade( KnightsSet.m_Points );
 				pKnights->bRanking = KnightsSet.m_Ranking;
 
-				for(i=0; i<MAX_CLAN; i++)	{
+				for(int i=0; i<MAX_CLAN; i++)	{
 					pKnights->arKnightsUser[i].byUsed = 0;
 					strcpy(pKnights->arKnightsUser[i].strUserName, "");
 				}	
@@ -3316,7 +3312,7 @@ BOOL CEbenezerDlg::LoadAllKnights()
 				pKnights->m_byGrade = GetKnightsGrade( KnightsSet.m_Points );
 				pKnights->m_byRanking = KnightsSet.m_Ranking;
 
-				for(i=0; i<MAX_CLAN; i++)	{
+				for(int i=0; i<MAX_CLAN; i++)	{
 					pKnights->m_arKnightsUser[i].byUsed = 0;
 					strcpy(pKnights->m_arKnightsUser[i].strUserName, "");
 				}	
@@ -3362,7 +3358,7 @@ BOOL CEbenezerDlg::LoadAllKnights()
 			pKnights->m_byGrade = GetKnightsGrade( KnightsSet.m_Points );
 			pKnights->m_byRanking = KnightsSet.m_Ranking;
 
-			for(i=0; i<MAX_CLAN; i++)	{
+			for(int i=0; i<MAX_CLAN; i++)	{
 				pKnights->m_arKnightsUser[i].byUsed = 0;
 				strcpy(pKnights->m_arKnightsUser[i].strUserName, "");
 			}	
@@ -3434,10 +3430,10 @@ int  CEbenezerDlg::GetKnightsAllMembers(int knightsindex, char *temp_buff, int& 
 
 	CUser* pUser = NULL;
 	CKnights* pKnights = NULL;
-	int count = 0, i=0;
+	int count = 0;
 
 	if( type == 0 )	{
-		for( i=0; i<MAX_USER; i++ ) {
+		for( int i=0; i<MAX_USER; i++ ) {
 			pUser = (CUser*)m_Iocport.m_SockArray[i];
 			if( !pUser ) continue;
 			if( pUser->m_pUserData->m_bKnights == knightsindex ) {		// 같은 소속의 클랜..
@@ -3455,7 +3451,7 @@ int  CEbenezerDlg::GetKnightsAllMembers(int knightsindex, char *temp_buff, int& 
 		pKnights = m_KnightsArray.GetData( knightsindex );
 		if( !pKnights ) return 0;
 
-		for( i=0; i<MAX_CLAN; i++ )	{
+		for( int i=0; i<MAX_CLAN; i++ )	{
 			if( pKnights->m_arKnightsUser[i].byUsed == 1 )	{	// 
 				pUser = GetUserPtr( pKnights->m_arKnightsUser[i].strUserName, 0x02 );
 				if( pUser )	{		// 접속중인 회원
@@ -3912,7 +3908,7 @@ BOOL CEbenezerDlg::LoadKnightsRankTable()
 	SetShort( temp_buff, strlen(strElmoCaptainName), temp_index );
 	SetString( temp_buff, strElmoCaptainName, strlen(strElmoCaptainName), temp_index );
 
-	for( i=0; i<MAX_USER; i++) {
+	for( int i=0; i<MAX_USER; i++) {
 		pUser = (CUser*)m_Iocport.m_SockArray[i];
 		if( !pUser )
 			continue;

--- a/src/server/Ebenezer/IOCPort.cpp
+++ b/src/server/Ebenezer/IOCPort.cpp
@@ -320,7 +320,6 @@ DWORD WINAPI SendWorkerThread(LPVOID lp)
 	DWORD			dwFlag = 0;
 	CIOCPSocket2*	pSocket = NULL;
 	char			pBuff[REGION_BUFF_SIZE];
-	int				len = 0, i=0;
 
 	while (1)
 	{
@@ -337,11 +336,11 @@ DWORD WINAPI SendWorkerThread(LPVOID lp)
 				switch( pOvl->Offset )
 				{
 				case	OVL_SEND:
-					for( i=0; i<MAX_USER; i++ ) {
+					for( int i=0; i<MAX_USER; i++ ) {
 						pSocket = pIocport->m_SockArray[i];
 						if( pSocket ) {
 							if( pSocket->m_pRegionBuffer->iLength == 0 ) continue;
-							len = 0;
+							int len = 0;
 							memset( pBuff, 0x00, REGION_BUFF_SIZE );
 							pSocket->RegioinPacketClear( pBuff, len );
 							if( len < 500 )
@@ -397,7 +396,7 @@ void CIOCPort::DeleteAllArray()
 	}
 	delete[] m_SockArray;
 
-	for ( i=0; i < m_SocketArraySize; i++ ) {
+	for ( int i=0; i < m_SocketArraySize; i++ ) {
 		if ( m_SockArrayInActive[i] != NULL ) {
 			delete m_SockArrayInActive[i];
 			m_SockArrayInActive[i] = NULL;
@@ -405,7 +404,7 @@ void CIOCPort::DeleteAllArray()
 	}
 	delete[] m_SockArrayInActive;
 
-	for ( i=0; i < m_ClientSockSize; i++ ) {
+	for ( int i=0; i < m_ClientSockSize; i++ ) {
 		if ( m_ClientSockArray[i] != NULL ) {
 			delete m_ClientSockArray[i];
 			m_ClientSockArray[i] = NULL;
@@ -428,16 +427,16 @@ void CIOCPort::Init(int serversocksize, int clientsocksize, int workernum)
 	}
 
 	m_SockArrayInActive = new CIOCPSocket2* [serversocksize];
-	for(i = 0; i<serversocksize; i++ ) {
+	for(int i = 0; i<serversocksize; i++ ) {
 		m_SockArrayInActive[i] = NULL;
 	}
 
 	m_ClientSockArray = new CIOCPSocket2* [clientsocksize];		// 해당 서버가 클라이언트로서 다른 컴터에 붙는 소켓수
-	for( i=0; i<clientsocksize; i++ ) {
+	for(int i=0; i<clientsocksize; i++ ) {
 		m_ClientSockArray[i] = NULL;
 	}
 
-	for( i = 0; i<serversocksize; i++)
+	for(int i = 0; i<serversocksize; i++)
 		m_SidList.push_back(i);
 
 	InitializeCriticalSection( &g_critical );

--- a/src/server/Ebenezer/Knights.cpp
+++ b/src/server/Ebenezer/Knights.cpp
@@ -59,7 +59,7 @@ void CKnights::InitializeValue()
 		memset( m_arKnightsUser[i].strUserName, 0x00, MAX_ID_SIZE+1);
 	}
 
-	for( i=0; i<MAX_KNIGHTS_BANK; i++ )	{
+	for(int i=0; i<MAX_KNIGHTS_BANK; i++ )	{
 		m_StashItem[i].nNum = 0;
 		m_StashItem[i].sCount = 0;
 		m_StashItem[i].sDuration = 0;

--- a/src/server/Ebenezer/KnightsManager.cpp
+++ b/src/server/Ebenezer/KnightsManager.cpp
@@ -674,7 +674,7 @@ fail_return:
 
 void CKnightsManager::CurrentKnightsMember(CUser *pUser, char* pBuf)
 {
-	int index = 0, send_index = 0, buff_index = 0, count = 0, i=0, page = 0, start = 0;
+	int index = 0, send_index = 0, buff_index = 0, count = 0, page = 0, start = 0;
 	char send_buff[128]; memset( send_buff, 0x00, 128 );
 	char temp_buff[4096]; memset( temp_buff, 0x00, 4096 );
 	CUser* pTUser = NULL;
@@ -694,7 +694,7 @@ void CKnightsManager::CurrentKnightsMember(CUser *pUser, char* pBuf)
 	page = GetShort( pBuf, index );
 	start = page * 10;			// page : 0 ~
 
-	for(i=0; i<MAX_USER; i++ ) {
+	for(int i=0; i<MAX_USER; i++ ) {
 		pTUser = (CUser*)m_pMain->m_Iocport.m_SockArray[i];
 		if( !pTUser ) continue;
 		if( pTUser->m_pUserData->m_bKnights != pUser->m_pUserData->m_bKnights ) continue;

--- a/src/server/Ebenezer/MagicProcess.cpp
+++ b/src/server/Ebenezer/MagicProcess.cpp
@@ -1552,7 +1552,7 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 {
 	int damage = 0, send_index = 0, result = 1;     // Variable initialization. result == 1 : success, 0 : fail
 	char send_buff[128]; memset( send_buff, NULL, 128);
-	int i = 0, j = 0, k =0; int buff_test = 0; BOOL bType3Test = TRUE; BOOL bType4Test = TRUE; 	
+	int buff_test = 0; BOOL bType3Test = TRUE; BOOL bType4Test = TRUE; 	
 
 	_MAGIC_TABLE* pMagic = NULL;
 	pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
@@ -1569,7 +1569,7 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 
 	switch(pType->bType) {
 		case REMOVE_TYPE3:		// REMOVE TYPE 3!!!
-			for (i = 0 ; i < MAX_TYPE3_REPEAT ; i++) {
+			for (int i = 0 ; i < MAX_TYPE3_REPEAT ; i++) {
 				if (pTUser->m_bHPAmount[i] < 0) {
 					pTUser->m_fHPStartTime[i] = 0.0f;
 					pTUser->m_fHPLastTime[i] = 0.0f;   
@@ -1587,13 +1587,13 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 			}
 
 			buff_test = 0;
-			for (j = 0 ; j < MAX_TYPE3_REPEAT ; j++) {
+			for (int j = 0 ; j < MAX_TYPE3_REPEAT ; j++) {
 				buff_test += pTUser->m_bHPDuration[j];
 			}
 			if (buff_test == 0) pTUser->m_bType3Flag = FALSE;	
 //
 			// Check for Type 3 Curses.
-			for (k = 0 ; k < MAX_TYPE3_REPEAT ; k++) {
+			for (int k = 0 ; k < MAX_TYPE3_REPEAT ; k++) {
 				if (pTUser->m_bHPAmount[k] < 0) {
 					bType3Test = FALSE;
 					break;
@@ -1719,13 +1719,13 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 			//  end of Send Party Packet.....  */
 		
 			buff_test = 0;
-			for (i = 0 ; i < MAX_TYPE4_BUFF ; i++) {
+			for (int i = 0 ; i < MAX_TYPE4_BUFF ; i++) {
 				buff_test += pTUser->m_bType4Buff[i];
 			}
 			if (buff_test == 0) pTUser->m_bType4Flag = FALSE;
 
 			bType4Test = TRUE ;
-			for (j = 0 ; j < MAX_TYPE4_BUFF ; j++) {
+			for (int j = 0 ; j < MAX_TYPE4_BUFF ; j++) {
 				if (pTUser->m_bType4Buff[j] == 1) {
 					bType4Test = FALSE;
 					break;
@@ -1768,13 +1768,13 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 				pTUser->Send2AI_UserUpdateInfo();	// AI Server에 바끤 데이타 전송....		
 			
 				buff_test = 0;
-				for (i = 0 ; i < MAX_TYPE4_BUFF ; i++) {
+				for (int i = 0 ; i < MAX_TYPE4_BUFF ; i++) {
 					buff_test += pTUser->m_bType4Buff[i];
 				}
 				if (buff_test == 0) pTUser->m_bType4Flag = FALSE;
 
 				bType4Test = TRUE ;
-				for (j = 0 ; j < MAX_TYPE4_BUFF ; j++) {
+				for (int j = 0 ; j < MAX_TYPE4_BUFF ; j++) {
 					if (pTUser->m_bType4Buff[j] == 1) {
 						bType4Test = FALSE;
 						break;

--- a/src/server/Ebenezer/N3BASE/N3ShapeMgr.cpp
+++ b/src/server/Ebenezer/N3BASE/N3ShapeMgr.cpp
@@ -304,7 +304,7 @@ void CN3ShapeMgr::GenerateCollisionData()
 	memset(m_pvCollisions, 0, sizeof(__Vector3) * nFC * 3);
 
 	int nCPC = 0; // Collision Polygon Count
-	for(i = 0; i < iSC; i++) // Shape 에 있는 충돌 메시 만큼 데이터 복사..
+	for(int i = 0; i < iSC; i++) // Shape 에 있는 충돌 메시 만큼 데이터 복사..
 	{
 		CN3VMesh* pVMesh = m_Shapes[i]->CollisionMesh();
 		if (NULL == pVMesh) continue;
@@ -347,7 +347,7 @@ void CN3ShapeMgr::GenerateCollisionData()
 	// 각 선분이 셀에 걸쳐 있는지 혹은 포함되어 있는지 등등 판단해서 인덱스 생성을 한다.
 	int xSMax = (int)(m_fMapWidth / CELL_SUB_SIZE);
 	int zSMax = (int)(m_fMapLength / CELL_SUB_SIZE);
-	for(i = 0; i < nFC; i++)
+	for(int i = 0; i < nFC; i++)
 	{
 		__Vector3 vEdge[3][2];
 
@@ -610,7 +610,6 @@ void CN3ShapeMgr::Tick()
 	int zMainE = (int)((s_CameraData.vEye.z + s_CameraData.fFP) / CELL_MAIN_SIZE); if(zMainE > MAX_CELL_MAIN) zMainE = MAX_CELL_MAIN;
 	
 	__CellMain* pCellCur = NULL;
-	int i = 0, iShp = 0, iSIndex = 0, iSC = m_Shapes.size();;
 	m_ShapesToRender.clear();
 	// 렌더링 리스트 비우고..
 	
@@ -621,11 +620,10 @@ void CN3ShapeMgr::Tick()
 			pCellCur = m_pCells[xM][zM];
 			if(NULL == pCellCur) continue;
 
-			int iSCC = pCellCur->nShapeCount;
-			for(i = 0; i < iSCC; i++)
+			for(int i = 0; i < pCellCur->nShapeCount; i++)
 			{
-				iSIndex = pCellCur->pwShapeIndices[i];
-				__ASSERT(iSIndex >= 0 && iSIndex < iSC, "Shape Index is invalid");
+				int iSIndex = pCellCur->pwShapeIndices[i];
+				__ASSERT(iSIndex >= 0 && iSIndex < m_Shapes.size(), "Shape Index is invalid");
 
 				m_Shapes[iSIndex]->Tick();
 				if(m_Shapes[iSIndex]->m_bDontRender) continue;
@@ -738,7 +736,7 @@ bool CN3ShapeMgr::CheckCollision(	const __Vector3& vPos,		// 충돌 위치
 			if(iSC > 1) qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance); // 카메라 거리에 따라 정렬하고..
 
 			CN3VMesh* pVMesh = NULL;
-			for(i = 0; i < iSC; i++)
+			for(int i = 0; i < iSC; i++)
 			{
 				pVMesh = Shapes[i]->CollisionMesh();
 				if(true == pVMesh->CheckCollision(Shapes[i]->m_Matrix, vPos, vPosNext, pvCol, pvNormal)) return true;
@@ -852,7 +850,7 @@ CN3Shape* CN3ShapeMgr::Pick(int iXScreen, int iYScreen, bool bMustHaveEvent, __V
 	for(int i = 0; it != itEnd; it++, i++) { Shapes[i] = *it; }
 	qsort(&(Shapes[0]), iSC, 4, SortByCameraDistance);
 
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		if(bMustHaveEvent && Shapes[i]->m_iEventID <= 0) continue; // 이벤트가 있어야 한다면...
 		if(Shapes[i]->CheckCollisionPrecisely(vPos, vDir, pvPick) >= 0)

--- a/src/server/Ebenezer/User.cpp
+++ b/src/server/Ebenezer/User.cpp
@@ -1631,7 +1631,7 @@ void CUser::SendMyInfo()
 	pMap = (C3DMap*)m_pMain->m_ZoneArray[m_iZoneIndex];
 	if( !pMap ) return;
 
-	int  send_index = 0, i=0, iLength = 0;
+	int  send_index = 0, iLength = 0;
 	char send_buff[2048];
 	memset( send_buff, NULL, 2048);
 
@@ -1759,16 +1759,16 @@ void CUser::SendMyInfo()
 // 이거 나중에 꼭 주석해 --;
 	SetByte( send_buff, m_pUserData->m_bAuthority, send_index );
 //
-	for(i=0; i<9; i++)
+	for(int i=0; i<9; i++)
 		SetByte(send_buff, m_pUserData->m_bstrSkill[i], send_index);
 
-	for(i=0; i<SLOT_MAX; i++ ) {
+	for(int i=0; i<SLOT_MAX; i++ ) {
 		SetDWORD( send_buff, m_pUserData->m_sItemArray[i].nNum, send_index );
 		SetShort( send_buff, m_pUserData->m_sItemArray[i].sDuration, send_index );
 		SetShort( send_buff, m_pUserData->m_sItemArray[i].sCount, send_index );
 	}
 
-	for( i=0; i<HAVE_MAX; i++ ) {
+	for(int i=0; i<HAVE_MAX; i++ ) {
 		SetDWORD( send_buff, m_pUserData->m_sItemArray[SLOT_MAX+i].nNum, send_index );
 		SetShort( send_buff, m_pUserData->m_sItemArray[SLOT_MAX+i].sDuration, send_index );
 		SetShort( send_buff, m_pUserData->m_sItemArray[SLOT_MAX+i].sCount, send_index );
@@ -2635,7 +2635,7 @@ void CUser::InsertRegion(int del_x, int del_z)
 
 void CUser::RequestUserIn(char *pBuf)
 {
-	int index = 0, uid = -1, user_count = 0, buff_index = 0, t_count = 0, i=0,j=0, iLength=0;
+	int index = 0, uid = -1, user_count = 0, buff_index = 0, t_count = 0, iLength=0;
 	CUser* pUser = NULL;
 	CKnights* pKnights = NULL;
 	char buff[40960];
@@ -2643,7 +2643,7 @@ void CUser::RequestUserIn(char *pBuf)
 
 	buff_index = 3;	// packet command 와 user_count 는 나중에 셋팅한다...
 	user_count = GetShort( pBuf, index );
-	for( i=0; i<user_count; i++ ) {
+	for(int i=0; i<user_count; i++ ) {
 		uid = GetShort( pBuf, index );
 		if( uid < 0 || uid >= MAX_USER )
 			continue;
@@ -2732,14 +2732,14 @@ void CUser::RequestNpcIn(char *pBuf)
 {
 	if( m_pMain->m_bPointCheckFlag == FALSE)	return;	// 포인터 참조하면 안됨
 
-	int index = 0, nid = -1, npc_count = 0, buff_index = 0, t_count = 0, i=0,j=0;
+	int index = 0, nid = -1, npc_count = 0, buff_index = 0, t_count = 0;
 	CNpc* pNpc = NULL;
 	char buff[20480];
 	memset( buff, NULL, 20480 );
 
 	buff_index = 3;	// packet command 와 user_count 는 나중에 셋팅한다...
 	npc_count = GetShort( pBuf, index );
-	for( i=0; i<npc_count; i++ ) {
+	for(int i=0; i<npc_count; i++ ) {
 		nid = GetShort( pBuf, index );
 		if( nid < 0 || nid > NPC_BAND+NPC_BAND)
 			continue;
@@ -2973,7 +2973,7 @@ void CUser::SetSlotItemValue()	// 착용한 아이템의 값(타격률, 회피율, 데미지)을 �
 	}
 
 // Also add the weight of items in the inventory....
-	for(i=0 ; i < HAVE_MAX+SLOT_MAX ; i++)  {
+	for(int i=0 ; i < HAVE_MAX+SLOT_MAX ; i++)  {
 		if(m_pUserData->m_sItemArray[i].nNum <= 0) continue;
 
 		pTable = m_pMain->m_ItemtableArray.GetData( m_pUserData->m_sItemArray[i].nNum );
@@ -4253,7 +4253,7 @@ void CUser::NpcEvent(char *pBuf)
 		SetByte( send_buf, WIZ_WAREHOUSE, send_index );
 		SetByte( send_buf, WAREHOUSE_OPEN, send_index );
 		SetDWORD( send_buf, m_pUserData->m_iBank, send_index );
-		for( i=0; i<WAREHOUSE_MAX; i++ ) {
+		for(int i=0; i<WAREHOUSE_MAX; i++ ) {
 			SetDWORD( send_buf, m_pUserData->m_sWarehouseArray[i].nNum, send_index );
 			SetShort( send_buf, m_pUserData->m_sWarehouseArray[i].sDuration, send_index );
 			SetShort( send_buf, m_pUserData->m_sWarehouseArray[i].sCount, send_index );
@@ -4553,7 +4553,7 @@ BOOL CUser::IsValidName(char *name)
 
 void CUser::ItemGet(char *pBuf)
 {
-	int index = 0, send_index = 0, bundle_index = 0, itemid = 0, count = 0, i=0;
+	int index = 0, send_index = 0, bundle_index = 0, itemid = 0, count = 0;
 	BYTE pos;
 	_ITEM_TABLE* pTable = NULL;
 	char send_buff[256];	memset( send_buff, NULL, 256 );
@@ -4577,7 +4577,7 @@ void CUser::ItemGet(char *pBuf)
 	if( !pItem ) goto fail_return;
 
 	itemid = GetDWORD( pBuf, index );
-
+	int i;
 	for(i=0; i<6; i++) {
 		if( pItem->itemid[i] == itemid )
 			break;
@@ -4666,7 +4666,7 @@ void CUser::ItemGet(char *pBuf)
 					}
 				}
 				if( usercount == 0 ) goto fail_return;
-				for( i=0; i<8; i++ ) {
+				for( int i=0; i<8; i++ ) {
 					if( pParty->uid[i] != -1 || pParty->uid[i] >= MAX_USER ) {
 						pUser = (CUser*)m_pMain->m_Iocport.m_SockArray[pParty->uid[i]];
 						if( !pUser ) continue;
@@ -4989,7 +4989,7 @@ void CUser::PartyCancel()	// 거절한 사람한테 온다... 리더를 찾아서 알려주는 함수
 
 void CUser::PartyRequest(int memberid, BOOL bCreate)	//리더에게 패킷이 온거다..
 {
-	int index = 0, send_index = 0, result = -1, i=0;
+	int index = 0, send_index = 0, result = -1;
 	CUser* pUser = NULL;
 	_PARTY_GROUP* pParty = NULL;
 	char send_buff[256]; memset( send_buff, 0x00, 256 );
@@ -5015,6 +5015,7 @@ void CUser::PartyRequest(int memberid, BOOL bCreate)	//리더에게 패킷이 온거다..
 	if( !bCreate ) {	// 기존의 파티에 추가하는 경우
 		pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
 		if( !pParty ) goto fail_return;
+		int i;
 		for(i=0; i<8; i++) {
 			if( pParty->uid[i] < 0 ) 
 				break;
@@ -5128,7 +5129,8 @@ void CUser::PartyInsert()	// 본인이 추가 된다.  리더에게 패킷이 가는것이 아님
 		Send( send_buff, send_index );	// 추가된 사람에게 기존 인원 다 받게함..
 	}
 
-	for( i=0; i<8; i++ ) {
+	int i;
+	for(i=0; i<8; i++ ) {
 		if( pParty->uid[i] == -1 ) {		// Party Structure 에 추가
 			pParty->uid[i] = m_Sid;
 			pParty->sMaxHp[i] = m_iMaxHp;
@@ -5236,7 +5238,7 @@ void CUser::PartyRemove(int memberid)
 	SetShort( send_buff, memberid, send_index );
 	m_pMain->Send_PartyMember( m_sPartyIndex, send_buff, send_index );	// 삭제된 인원을 브로드캐스팅..제거될 사람한테두 패킷이 간다.
 
-	for( i=0; i<8; i++ ) {			// 파티가 유효한 경우 에는 파티 리스트에서 뺀다.
+	for( int i=0; i<8; i++ ) {			// 파티가 유효한 경우 에는 파티 리스트에서 뺀다.
 		if( pParty->uid[i] != -1 ) {
 			if( pParty->uid[i] == memberid ) {
 				pParty->uid[i] = -1;
@@ -5976,8 +5978,8 @@ void CUser::ChatTargetSelect(char *pBuf)
 	idlen = GetShort( pBuf, index );
 	if( idlen > MAX_ID_SIZE || idlen < 0 ) return;
 	GetString( chatid, pBuf, idlen, index );
-
-	for( int i=0; i<MAX_USER; i++ ) {
+	int i;
+	for( i=0; i<MAX_USER; i++ ) {
 		pUser = (CUser*)m_pMain->m_Iocport.m_SockArray[i];
 		if( pUser && pUser->GetState() == STATE_GAMESTART ) {
 			if( _strnicmp( chatid, pUser->m_pUserData->m_id, MAX_ID_SIZE ) == 0 ) {
@@ -7835,7 +7837,7 @@ void CUser::GoldChange(short tid, int gold)
 
 			if( usercount == 0 ) return;
 
-			for( i=0; i<8; i++ ) {		
+			for( int i=0; i<8; i++ ) {		
 				if( pParty->uid[i] != -1 || pParty->uid[i] >= MAX_USER ) {
 					CUser * pUser = NULL;
 					pUser = (CUser*)m_pMain->m_Iocport.m_SockArray[pParty->uid[i]];
@@ -9938,7 +9940,8 @@ BOOL CUser::RobItem(int itemid, short count)
 	pTable = m_pMain->m_ItemtableArray.GetData( itemid );
 	if( !pTable ) return FALSE;
 
-	for ( int i = SLOT_MAX ; i < SLOT_MAX + HAVE_MAX * type ; i++ ) {
+	int i = SLOT_MAX;
+	for ( ; i < SLOT_MAX + HAVE_MAX * type ; i++ ) {
 		if( m_pUserData->m_sItemArray[i].nNum == itemid ) {		
 			if (!pTable->m_bCountable) {	// Remove item from inventory (Non-countable items)
 				m_pUserData->m_sItemArray[i].nNum = 0;

--- a/src/server/ItemManager/ItemManager.vcxproj
+++ b/src/server/ItemManager/ItemManager.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -94,7 +93,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/server/LogInServer/IOCPort.cpp
+++ b/src/server/LogInServer/IOCPort.cpp
@@ -320,7 +320,7 @@ void CIOCPort::DeleteAllArray()
 	}
 	delete[] m_SockArray;
 
-	for ( i=0; i < m_SocketArraySize; i++ ) {
+	for ( int i=0; i < m_SocketArraySize; i++ ) {
 		if ( m_SockArrayInActive[i] != NULL ) {
 			delete m_SockArrayInActive[i];
 			m_SockArrayInActive[i] = NULL;
@@ -328,7 +328,7 @@ void CIOCPort::DeleteAllArray()
 	}
 	delete[] m_SockArrayInActive;
 
-	for ( i=0; i < m_ClientSockSize; i++ ) {
+	for ( int i=0; i < m_ClientSockSize; i++ ) {
 		if ( m_ClientSockArray[i] != NULL ) {
 			delete m_ClientSockArray[i];
 			m_ClientSockArray[i] = NULL;
@@ -351,16 +351,16 @@ void CIOCPort::Init(int serversocksize, int clientsocksize, int workernum)
 	}
 
 	m_SockArrayInActive = new CIOCPSocket2* [serversocksize];
-	for(i = 0; i<serversocksize; i++ ) {
+	for(int i = 0; i<serversocksize; i++ ) {
 		m_SockArrayInActive[i] = NULL;
 	}
 
 	m_ClientSockArray = new CIOCPSocket2* [clientsocksize];		// 해당 서버가 클라이언트로서 다른 컴터에 붙는 소켓수
-	for( i=0; i<clientsocksize; i++ ) {
+	for(int i=0; i<clientsocksize; i++ ) {
 		m_ClientSockArray[i] = NULL;
 	}
 
-	for( i = 0; i<serversocksize; i++)
+	for(int i = 0; i<serversocksize; i++)
 		m_SidList.push_back(i);
 
 	InitializeCriticalSection( &g_critical );

--- a/src/server/LogInServer/User.cpp
+++ b/src/server/LogInServer/User.cpp
@@ -45,7 +45,7 @@ void CUser::CloseProcess()
 
 void CUser::Parsing(int len, char *pData)
 {
-	int index = 0, send_index = 0, i=0, client_version = 0;
+	int index = 0, send_index = 0, client_version = 0;
 	char buff[2048]; memset( buff, 0x00, 2048 );
 	BYTE command = GetByte( pData, index );
 
@@ -59,7 +59,7 @@ void CUser::Parsing(int len, char *pData)
 		m_pMain->m_DBProcess.LoadUserCountList();		// 기범이가 ^^;
 		SetByte( buff, LS_SERVERLIST, send_index );
 		SetByte( buff, m_pMain->m_nServerCount, send_index );
-		for(i=0; i<m_pMain->m_ServerList.size(); i++) {		
+		for(int i=0; i<m_pMain->m_ServerList.size(); i++) {		
 			SetShort( buff, strlen(m_pMain->m_ServerList[i]->strServerIP), send_index );
 			SetString( buff, m_pMain->m_ServerList[i]->strServerIP, strlen(m_pMain->m_ServerList[i]->strServerIP), send_index );
 			SetShort( buff, strlen(m_pMain->m_ServerList[i]->strServerName), send_index );

--- a/src/server/LogInServer/VersionManager.vcxproj
+++ b/src/server/LogInServer/VersionManager.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/server/LogInServer/Zip.vcxproj
+++ b/src/server/LogInServer/Zip.vcxproj
@@ -65,7 +65,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Lib>
     </Lib>
@@ -91,7 +90,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Lib>
     </Lib>

--- a/src/tool/KscViewer/KscViewer.vcxproj
+++ b/src/tool/KscViewer/KscViewer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -97,7 +96,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/Launcher/Launcher/Launcher.vcxproj
+++ b/src/tool/Launcher/Launcher/Launcher.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -95,7 +94,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/Launcher/ZipArchive/ZipArchive.vcxproj
+++ b/src/tool/Launcher/ZipArchive/ZipArchive.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -89,7 +88,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/tool/N3CE/DlgChrProperty.cpp
+++ b/src/tool/N3CE/DlgChrProperty.cpp
@@ -238,7 +238,7 @@ void CDlgChrProperty::UpdateInfo()
 	int nPlug = m_CBChrPlug.GetCurSel();
 	int nPlugCount = pChr->PlugCount();
 	m_CBChrPlug.ResetContent();
-	for(i = 0; i < nPlugCount; i++)
+	for(int i = 0; i < nPlugCount; i++)
 	{
 		CString szTmp;
 		szTmp.Format("Plug : %d", i);

--- a/src/tool/N3CE/FormViewProperty.cpp
+++ b/src/tool/N3CE/FormViewProperty.cpp
@@ -558,7 +558,7 @@ void CFormViewProperty::UpdateAllInfo()
 	m_TreeChr.Expand(m_hTI_Parts, TVE_EXPAND);
 
 	nPC = pChr->PlugCount();
-	for(i = 0; i < nPC; i++)
+	for(int i = 0; i < nPC; i++)
 	{
 		if(NULL == pChr->Plug(i)) 
 		{

--- a/src/tool/N3CE/N3CE.vcxproj
+++ b/src/tool/N3CE/N3CE.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/N3CE/N3CEDoc.cpp
+++ b/src/tool/N3CE/N3CEDoc.cpp
@@ -171,7 +171,7 @@ BOOL CN3CEDoc::OnSaveDocument(LPCTSTR lpszPathName)
 
 	CN3CPlugBase* pPlug = NULL;
 	int nCPC = pChr->PlugCount();
-	for(i = 0; i < nCPC; i++)
+	for(int i = 0; i < nCPC; i++)
 	{
 		pPlug = pChr->Plug(i);
 		pPlug->SaveToFile();
@@ -223,7 +223,7 @@ void CN3CEDoc::OnFileSaveAsOneFolder()
 
 	CN3CPlugBase* pPlug = NULL;
 	int nCPC = pChr->PlugCount();
-	for(i = 0; i < nCPC; i++)
+	for(int i = 0; i < nCPC; i++)
 	{
 		pPlug = pChr->Plug(i);
 		if(NULL == pPlug) continue;
@@ -246,7 +246,7 @@ void CN3CEDoc::OnFileSaveAsOneFolder()
 
 	CN3CPart* pPart = NULL;
 	nCPC = pChr->PartCount();
-	for(i = 0; i < nCPC; i++)
+	for(int i = 0; i < nCPC; i++)
 	{
 		pPart = pChr->Part(i);
 		if(NULL == pPart) continue;
@@ -360,7 +360,7 @@ void CN3CEDoc::OnToolOptimizeAnimationData()
 	}
 
 	float fOffsetCur = fSamplingRate;
-	for(i = 0; i < iAniCount; i++) // Animation Key Frame 다시 계산..
+	for(int i = 0; i < iAniCount; i++) // Animation Key Frame 다시 계산..
 	{
 		__AnimData* pAD = pAniCtrl->DataGet(i);
 

--- a/src/tool/N3CE/TransDummy.cpp
+++ b/src/tool/N3CE/TransDummy.cpp
@@ -75,8 +75,7 @@ void CTransDummy::InitDummyCube(int iType, __DUMMYCUBE* pDummyCube, __Vector3& v
 	pDummyCube->Vertices[30].Set(vCubeV[6], vCubeN[5], color);	pDummyCube->Vertices[31].Set(vCubeV[2], vCubeN[5], color);	pDummyCube->Vertices[32].Set(vCubeV[1], vCubeN[5], color);
 	pDummyCube->Vertices[33].Set(vCubeV[6], vCubeN[5], color);	pDummyCube->Vertices[34].Set(vCubeV[1], vCubeN[5], color);	pDummyCube->Vertices[35].Set(vCubeV[5], vCubeN[5], color);
 
-	int i;
-	for (i=0; i<NUM_CUBEVERTEX; ++i)
+	for (int i=0; i<NUM_CUBEVERTEX; ++i)
 	{
 		pDummyCube->Vertices[i].x += vOffset.x;
 		pDummyCube->Vertices[i].y += vOffset.y;
@@ -98,13 +97,12 @@ void CTransDummy::Tick()
 	ReCalcMatrix();
 
 	// 거리에 따라 정렬
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		__Vector3 vPos = m_DummyCubes[i].vCenterPos*m_Matrix;
 		m_DummyCubes[i].fDistance = (vPos - s_CameraData.vEye).Magnitude();
 	}
-	for (i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
+	for (int i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
 	qsort(m_pSortedCubes, sizeof(__DUMMYCUBE*), NUM_DUMMY, SortCube);
 }
 
@@ -147,8 +145,7 @@ void CTransDummy::Render()
 
 	// Cube 그리기
 	hr = s_lpD3DDev->SetFVF(FVF_XYZNORMALCOLOR);
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		ASSERT(m_pSortedCubes[i]);
 		hr = s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLELIST, 12, m_pSortedCubes[i]->Vertices, sizeof(__VertexXyzNormalColor));
@@ -181,10 +178,9 @@ __DUMMYCUBE* CTransDummy::Pick(int x, int y)
 	CPick pick;
 	pick.SetPickXY(x, y);
 
-	int i, j;
-	for (i=NUM_DUMMY-1; i>=0; --i)
+	for (int i=NUM_DUMMY-1; i>=0; --i)
 	{
-		for (j=0; j<12; ++j)
+		for (int j=0; j<12; ++j)
 		{
 			__Vector3 v1, v2, v3;
 			__VertexXyzNormalColor* pVertex;
@@ -305,11 +301,11 @@ void CTransDummy::GetPickRay(POINT point, __Vector3& vDir, __Vector3& vOrig)
 
 void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vector3* pvDiffScale)
 {
-	int i, iSize = m_SelObjArray.GetSize();
+	int iSize = m_SelObjArray.GetSize();
 	if (iSize<=0) return;
 	if (pvDiffPos)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			CN3Transform* pSelObj = m_SelObjArray.GetAt(i);
 			_ASSERT(pSelObj);
@@ -318,7 +314,7 @@ void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vec
 	}
 	if (pqDiffRot)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			CN3Transform* pSelObj = m_SelObjArray.GetAt(i);
 			_ASSERT(pSelObj);
@@ -329,7 +325,7 @@ void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vec
 	}
 	if (pvDiffScale)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			CN3Transform* pSelObj = m_SelObjArray.GetAt(i);
 			_ASSERT(pSelObj && m_vPrevScaleArray);

--- a/src/tool/N3FXE/DlgEditPartParticle.cpp
+++ b/src/tool/N3FXE/DlgEditPartParticle.cpp
@@ -433,7 +433,7 @@ bool CDlgEditPartParticle::LoadPartScript(const char* szPath)
 	m_bChangeColor = (BOOL)pPart->m_bChangeColor;
 
 	DWORD color;
-	for(i=0;i<NUM_KEY_COLOR;i++)
+	for(int i=0;i<NUM_KEY_COLOR;i++)
 	{
 		if(pPart->GetColor(i, color)) m_Color[i] = color;
 		if(pPart->m_bChangeColorKey[i]) m_bColorKey[i] = true;

--- a/src/tool/N3FXE/N3FXE.vcxproj
+++ b/src/tool/N3FXE/N3FXE.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/N3Indoor/DlgBase.cpp
+++ b/src/tool/N3Indoor/DlgBase.cpp
@@ -122,7 +122,6 @@ BOOL CDlgBase::OnInitDialog()
 	/////////////////////////////////////
 
 
-	int i = 0;
 	CString str, strTmp;
 
 	/////////////////////////////////////
@@ -193,7 +192,7 @@ D3DTOP_BUMPENVMAP|D3DTOP_BUMPENVMAPLUMINANCE|D3DTOP_DOTPRODUCT|D3DTOP_MULTIPLYAD
 	m_CBChrPart.SetCurSel(0);
 
 	m_CBChrLOD.ResetContent();
-	for(i = 0; i < MAX_CHR_LOD; i++) { strTmp.Format("LOD : %d", i); m_CBChrLOD.AddString(strTmp); }
+	for(int i = 0; i < MAX_CHR_LOD; i++) { strTmp.Format("LOD : %d", i); m_CBChrLOD.AddString(strTmp); }
 	m_CBChrLOD.SetCurSel(0);
 
 	m_LPCPart.AddPropItem("Part Type", "", PIT_COMBO, "머리카락|얼굴|상체|하체|손|발|??|");
@@ -592,7 +591,7 @@ void CDlgBase::UpdateInfo()
 		int nPlug = m_CBChrPlug.GetCurSel();
 		int nPlugCount = pC->PlugCount();
 		m_CBChrPlug.ResetContent();
-		for(i = 0; i < nPlugCount; i++)
+		for(int i = 0; i < nPlugCount; i++)
 		{
 			CString szTmp;
 			szTmp.Format("Plug : %d", i);

--- a/src/tool/N3Indoor/DlgSceneGraph.cpp
+++ b/src/tool/N3Indoor/DlgSceneGraph.cpp
@@ -190,14 +190,13 @@ void CDlgSceneGraph::UpdateTreeItem(HTREEITEM hParent, CN3Base* pBase)
 		str.Format("Scene : %s", m_pSceneRef->m_szName.c_str());
 		m_Tree.SetItemText(hItem, str);
 
-		int i = 0;
 		HTREEITEM hItem2 = NULL;
 
 		if (m_dwFlag & OBJ_SHAPE)
 		{
 			hItem2 = m_Tree.InsertItem("Shape", hItem);
 			int nSC = m_pSceneRef->ShapeCount();
-			for(i = 0; i < nSC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->ShapeGet(i));
+			for(int i = 0; i < nSC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->ShapeGet(i));
 			m_Tree.SortChildren(hItem2);
 		}
 	}

--- a/src/tool/N3Indoor/DlgShapeList.cpp
+++ b/src/tool/N3Indoor/DlgShapeList.cpp
@@ -339,7 +339,7 @@ void CDlgShapeList::OnBtnSort()
 		m_ListShape.ResetContent();
 
 		SMIter it = Map.begin();
-		for(i=0;i<cnt;i++)
+		for(int i=0;i<cnt;i++)
 		{
 			std::string str = (*it).first;
 			CN3Shape* pShape = (*it).second;
@@ -372,7 +372,7 @@ void CDlgShapeList::OnBtnSort()
 		m_ListShape.ResetContent();
 
 		SIMIter it = Map.begin();
-		for(i=0;i<cnt;i++)
+		for(int i=0;i<cnt;i++)
 		{
 			std::string str = (*it).first;
 			ShapeInfo* pSI = (*it).second;

--- a/src/tool/N3Indoor/DlgUnusedFiles.cpp
+++ b/src/tool/N3Indoor/DlgUnusedFiles.cpp
@@ -95,7 +95,7 @@ void CDlgUnusedFiles::UpdateAll()
 	}
 
 	iFNC = m_InvalidFileNames.GetSize();
-	for(i = 0; i < iFNC; i++)
+	for(int i = 0; i < iFNC; i++)
 	{
 		m_ListInvalidObjects.AddString(m_InvalidFileNames[i]);
 	}

--- a/src/tool/N3Indoor/MainFrm.cpp
+++ b/src/tool/N3Indoor/MainFrm.cpp
@@ -865,7 +865,7 @@ void CMainFrame::OnTipDeleteObj()
 
 void CMainFrame::TotalValidateCheckAfterDelete()
 {
-	int i, iSize;
+	int iSize;
 	bool bFound;
 	CPortalVolume* pVol;
 	COrganizeView* pView = GetOrganizeView();
@@ -875,7 +875,7 @@ void CMainFrame::TotalValidateCheckAfterDelete()
 	{
 LOOP1:
 		iSize = m_pDummy->m_SelObjArray.GetSize();
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			bFound = false;
 
@@ -910,7 +910,7 @@ LOOP1:
 	{
 LOOP2:
 		iSize = m_SelVolArray.GetSize();
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			bFound = false;
 
@@ -1179,13 +1179,13 @@ void CMainFrame::OnTipDeleteUnusedFiles()
 	// 파일 지우기 대화상자 띄우기..
 	CDlgUnusedFiles dlg;
 	int iUFC = unusedFNs.size();
-	for(i = 0; i < iUFC; i++)
+	for(int i = 0; i < iUFC; i++)
 	{
 		dlg.m_FileNames.Add(unusedFNs[i].c_str());
 	}
 
 	int iIFC = invalidFNs.size();
-	for(i = 0; i < iIFC; i++)
+	for(int i = 0; i < iIFC; i++)
 	{
 		dlg.m_InvalidFileNames.Add(invalidFNs[i].c_str());
 	}

--- a/src/tool/N3Indoor/N3Indoor.vcxproj
+++ b/src/tool/N3Indoor/N3Indoor.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/N3Indoor/OrganizeView.cpp
+++ b/src/tool/N3Indoor/OrganizeView.cpp
@@ -1976,9 +1976,7 @@ void COrganizeView::RefreshFloorInfoAll(int iID)
 	std::vector<FloorInfo>	m_FloorVector;
 
 	CMainFrame* pFrm =  (CMainFrame* )AfxGetMainWnd();
-	FloorInfo FInfo;
-	int i; 
-	
+	FloorInfo FInfo;	
 	vfiter vfit = pFrm->m_FloorList.begin();
 	while(vfit != pFrm->m_FloorList.end())
 	{
@@ -1987,7 +1985,7 @@ void COrganizeView::RefreshFloorInfoAll(int iID)
 		vecVol.clear();
 
 		// Verify..
-		for (i = 0; i < iCount; i++)
+		for (int i = 0; i < iCount; i++)
 		{
 			if (iID != FInfo.m_vVolume[i]->m_iID)		
 				vecVol.push_back(FInfo.m_vVolume[i]);
@@ -1996,7 +1994,7 @@ void COrganizeView::RefreshFloorInfoAll(int iID)
 		iCount = vecVol.size();
 
 		// Verify..
-		for (i = 0; i < iCount; i++)
+		for (int i = 0; i < iCount; i++)
 			FInfo.m_vVolume.push_back(vecVol[i]);
 
 		if (iCount != 0)	// 한개라도 남아있으면.. 
@@ -2021,7 +2019,7 @@ void COrganizeView::RefreshFloorInfoAll(int iID)
 	pFrm->m_FloorList.clear();
 
 	iCount = m_FloorVector.size();
-	for (i = 0; i < iCount; i++)
+	for (int i = 0; i < iCount; i++)
 	{
 		pFrm->m_FloorList.push_back(m_FloorVector[i]);
 	}

--- a/src/tool/N3Indoor/PVSManager.cpp
+++ b/src/tool/N3Indoor/PVSManager.cpp
@@ -240,8 +240,6 @@ void CPVSManager::TickEdit()
 	CPortalVolume* pVol = NULL;
 	WVOL wvol;
 
-	int i = 0;
-
 	iter it = m_pPvsList.begin();
 	witer wit; 
 
@@ -258,7 +256,7 @@ void CPVSManager::TickEdit()
 	if (pFrm->m_pDummy)
 	{
 		int iSize = pFrm->m_pDummy->m_SelObjArray.GetSize();
-		for ( i = 0; i < iSize; i++ )
+		for ( int i = 0; i < iSize; i++ )
 		{
 			if (pFrm->m_pDummy->m_SelObjArray[i].eST == TYPE_VOLUME_TOTAL)
 			{
@@ -280,7 +278,7 @@ void CPVSManager::TickEdit()
 	if (pFrm->m_SelVolArray.GetSize() > 0)
 	{
 		int iSize = pFrm->m_SelVolArray.GetSize();
-		for ( i = 0; i < iSize; i++ )
+		for ( int i = 0; i < iSize; i++ )
 		{
 			pVol = (CPortalVolume* )pFrm->m_SelVolArray[i];
 			pVol->SetState(STATE_SELECTED);
@@ -1149,7 +1147,7 @@ bool CPVSManager::Load(HANDLE hFile)
 	CPortalVolume* pVol = NULL, *pVolTo = NULL;
 	int iID;
 
-	for( i = 0; i < m_iTotalCount; i++ )
+	for( int i = 0; i < m_iTotalCount; i++ )
 	{
 		ReadFile(hFile, &iID, sizeof(int), &dwNum, NULL);
 		if (m_iIncreseIndex < (iID+1))
@@ -1213,7 +1211,7 @@ bool CPVSManager::Load(HANDLE hFile)
 	// Floor..
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
 
-	for (i = 0; i < iCount; i++)
+	for (int i = 0; i < iCount; i++)
 	{
 		FloorInfo FInfo;
 		ReadFile(hFile, &FInfo.m_iFloor, sizeof(int), &dwNum, NULL);		

--- a/src/tool/N3Indoor/PortalVol.cpp
+++ b/src/tool/N3Indoor/PortalVol.cpp
@@ -426,19 +426,18 @@ void CPortalVol::Translate()
 
 void CPortalVol::SetState(e_PvsState ePS)
 {
-	int i = 0;
 	switch (ePS)
 	{
 		case STATE_NONE:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 				m_pvVertex[i].color = dwColorNone;
 			break;
 		case STATE_SELECTED:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 				m_pvVertex[i].color = dwColorSelected;
 			break;
 		case STATE_LINKED:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 				m_pvVertex[i].color = dwColorLinked;
 			break;
 	}
@@ -827,7 +826,7 @@ bool CPortalVol::IsInVolumnExEx(__Vector3 vec1, __Vector3 vec2)
 bool CPortalVol::IsInVolumnExExEx(__Vector3 vOrig, __Vector3 vDir, e_WallType eWT, __Vector3 &vPick)
 {
 	float ft, fu, fv;
-	int i;
+	int i = 0;
 
 	switch (eWT)
 	{

--- a/src/tool/N3Indoor/PortalVolume.cpp
+++ b/src/tool/N3Indoor/PortalVolume.cpp
@@ -388,19 +388,18 @@ void CPortalVolume::RenderExecute()
 
 void CPortalVolume::SetState(e_PvsState ePS, e_PvsWallType ePWT)
 {
-	int i = 0;
 	switch (ePS)
 	{
 		case STATE_NONE:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 				m_pvVertex[i].color = dwColorNone;
 			break;
 		case STATE_SELECTED:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 				m_pvVertex[i].color = dwColorSelected;
 			break;
 		case STATE_LINKED:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 			{
 				switch (ePWT)
 				{
@@ -426,7 +425,7 @@ void CPortalVolume::SetState(e_PvsState ePS, e_PvsWallType ePWT)
 			}
 			break;
 		case STATE_VOLUME_ONLY:
-			for(i = 0; i < 8; i++)
+			for(int i = 0; i < 8; i++)
 				m_pvVertex[i].color = dwColorSelectedVolOnly;
 			break;
 	}
@@ -720,7 +719,7 @@ bool CPortalVolume::Load(HANDLE hFile, bool bGameData)
 	// 링크된 Shape 갯수 로드..
 	int iCount = 0; int iSize = 0;
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
-	for (i = 0; i < iCount; i++)
+	for (int i = 0; i < iCount; i++)
 	{
 		ShapeInfo*	pSI = new ShapeInfo;
 		ReadFile(hFile, &pSI->m_iID, sizeof(int), &dwNum, NULL);
@@ -775,7 +774,7 @@ void CPortalVolume::LoadGameData(HANDLE hFile)
 	ReadFile(hFile, &iCount, sizeof(int), &dwNum, NULL);
 		
 	int iSize = 0, iSize_2 = 0, iSize_3 = 0;
-	for( i = 0; i < iCount; i++ )
+	for(int i = 0; i < iCount; i++ )
 	{
 		ShapePart* pSP = new ShapePart;
 		ReadFile(hFile, &pSP->m_iID, sizeof(int), &dwNum, NULL);
@@ -804,7 +803,7 @@ void CPortalVolume::LoadGameData(HANDLE hFile)
 
 	COrganizeView* pView = pFrm->GetOrganizeView();
 
-	for( i = 0; i < iCount; i++ )
+	for( int i = 0; i < iCount; i++ )
 	{
 		__ColIndex* pCI = new __ColIndex;
 		ReadFile(hFile, &pCI->m_iID, sizeof(int), &dwNum, NULL);		
@@ -1187,10 +1186,10 @@ bool CPortalVolume::IsInVolumnExExEx(__Vector3 vOrig, __Vector3 vDir, e_PvsWallT
 	}
 
 	__Vector3 vec[8];
-	for( i = 0; i < 8; i++)
+	for( int j = 0; j < 8; j++)
 	{
-		vec[i] = m_pvVertex[i];
-		vec[i] *= m_Matrix;
+		vec[j] = m_pvVertex[j];
+		vec[j] *= m_Matrix;
 	}
 
 	if(IntersectTriangle(vOrig, vDir, vec[m_pIndex[i]], vec[m_pIndex[i+1]], vec[m_pIndex[i+2]], ft, fu, fv, &vPick))
@@ -1211,7 +1210,7 @@ bool CPortalVolume::PickWithVolume(__Vector3 &vPos, __Vector3& vDir, __Vector3* 
 	}
 
 	float ft, fu, fv;
-	for (i = 0; i < 36; i += 6)
+	for (int i = 0; i < 36; i += 6)
 	{
 		if(IntersectTriangle(vPos, vDir, vec[m_pIndex[i]], vec[m_pIndex[i+1]], vec[m_pIndex[i+2]], ft, fu, fv, pVec))
 			return true;

--- a/src/tool/N3Indoor/PortalWall.cpp
+++ b/src/tool/N3Indoor/PortalWall.cpp
@@ -27,7 +27,6 @@ CPortalWall::CPortalWall(e_WallType eWT, CPortalVol* pVol)
 {
 	m_eWallType = eWT;
 	unsigned short* pIdx = m_pIndex;
-	int i;
 
 	if (pVol)
 	{
@@ -81,7 +80,7 @@ CPortalWall::CPortalWall(e_WallType eWT, CPortalVol* pVol)
 	}
 	else
 	{
-		for ( i = 0; i < 4; i++ )
+		for (int i = 0; i < 4; i++ )
 			m_pvVertex[i].Set(0.0f, 0.0f, 0.0f, dwColorNoneAlpha);
 	}
 
@@ -256,19 +255,18 @@ void CPortalWall::RenderExecute()
 
 void CPortalWall::SetState(e_PvsState ePS)
 {
-	int i = 0;
 	switch (ePS)
 	{
 		case STATE_NONE:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				m_pvVertex[i].color = dwColorNoneAlpha;
 			break;
 		case STATE_SELECTED:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				m_pvVertex[i].color = dwColorSelectedAlpha;
 			break;
 		case STATE_LINKED:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				m_pvVertex[i].color = dwColorLinkedAlpha;
 			break;
 	}

--- a/src/tool/N3Indoor/PvsBase.cpp
+++ b/src/tool/N3Indoor/PvsBase.cpp
@@ -43,7 +43,7 @@ void CPvsBase::Load(FILE* stream)
 			fread(&m_MtxMove.m[i][j], sizeof(float), 1, stream); 
 		}
 
-	for( i = 0; i < 4; i++ )
+	for( int i = 0; i < 4; i++ )
 		for( int j = 0; j < 4; j++ )
 		{
 			fread(&m_MtxScale.m[i][j], sizeof(float), 1, stream); 
@@ -58,7 +58,7 @@ void CPvsBase::Save(FILE* stream)
 			fwrite(&m_MtxMove.m[i][j], sizeof(float), 1, stream); 
 		}
 
-	for( i = 0; i < 4; i++ )
+	for( int i = 0; i < 4; i++ )
 		for( int j = 0; j < 4; j++ )
 		{
 			fwrite(&m_MtxScale.m[i][j], sizeof(float), 1, stream); 

--- a/src/tool/N3Indoor/PvsMgr.cpp
+++ b/src/tool/N3Indoor/PvsMgr.cpp
@@ -644,8 +644,6 @@ void CPvsMgr::PrepareCollisionDetect(CPortalVol* const pVol)
 void CPvsMgr::PrepareCollisionDetectOne(CPortalVol* const pVol, CPortalWall* const pWall)
 {
 #define SMALL_OFFSET 0.6f;
-	int i = 0;
-
 	__Collision Col;
 	Col.eWT = pWall->m_eWallType;
 	Col.Wvec[0] = pWall->m_pvVertex[0];
@@ -655,32 +653,32 @@ void CPvsMgr::PrepareCollisionDetectOne(CPortalVol* const pVol, CPortalWall* con
 	switch (Col.eWT)
 	{
 		case WALL_ZB:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				Col.Wvec[i] = pWall->m_pvVertex[i];	Col.Wvec[i].z = pWall->m_pvVertex[i].z + SMALL_OFFSET;
 			break;
 
 		case WALL_ZF:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				Col.Wvec[i] = pWall->m_pvVertex[i];	Col.Wvec[i].z = pWall->m_pvVertex[i].z - SMALL_OFFSET;
 			break;
 
 		case WALL_XL:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				Col.Wvec[i] = pWall->m_pvVertex[i];	Col.Wvec[i].x = pWall->m_pvVertex[i].x + SMALL_OFFSET;
 			break;
  
 		case WALL_XR:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				Col.Wvec[i] = pWall->m_pvVertex[i];	Col.Wvec[i].x = pWall->m_pvVertex[i].x - SMALL_OFFSET;
 			break;
 
 		case WALL_YT:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				Col.Wvec[i] = pWall->m_pvVertex[i];	Col.Wvec[i].y = pWall->m_pvVertex[i].y - SMALL_OFFSET;
 			break;
 
 		case WALL_YB:
-			for(i = 0; i < 4; i++)
+			for(int i = 0; i < 4; i++)
 				Col.Wvec[i] = pWall->m_pvVertex[i];	Col.Wvec[i].y = pWall->m_pvVertex[i].y + SMALL_OFFSET;
 			break;
 	}
@@ -778,7 +776,6 @@ bool CPvsMgr::CollisionDetectMain(CPortalVol* const pVolMy)
 	__Collision Col;
 	itviter ivit;
 	CPortalVol* pVol = NULL;
-	int i, j;
 	__Vector3 vDir;
 
 	iciter icit = m_ColList.begin();
@@ -787,9 +784,9 @@ bool CPvsMgr::CollisionDetectMain(CPortalVol* const pVolMy)
 		Col = *icit++;
 
 		// Volumn에 있는 충돌 체크 점들..
-		for( i = 0; i < 9; i++ )
+		for( int i = 0; i < 9; i++ )
 		{
-			for( j = 0; j < 5; j++ )
+			for( int j = 0; j < 5; j++ )
 			{
 				if ( (i == 8) && (j == 4) )
 				{
@@ -836,7 +833,7 @@ bool CPvsMgr::CollisionDetectMain(CPortalVol* const pVolMy)
 							break;
 					}
 				}
-again:;		
+again:
 			}
 		}
 	}
@@ -862,13 +859,13 @@ void CPvsMgr::RenderCollision(__Collision& col)
 		pvVertex[i].color = 0xffffffff;
 		pIndex[i] = i;
 	}
-	for( i = 0; i < 4; i++ )
+	for( int i = 0; i < 4; i++ )
 	{
 		pvWVertex[i] = col.Wvec[i];
 		pvWVertex[i].color = 0xffff0000;
 		pWIndex[i] = i;
 	}
-	for( i = 0; i < 8; i++ )
+	for( int i = 0; i < 8; i++ )
 	{
 		pvDVertex[i] = m_dcol.Vvec[i];
 		pvDVertex[i].color = 0xffff0000;
@@ -996,7 +993,7 @@ bool CPvsMgr::CheckPvsWall(const __Vector3& vOrig, const __Vector3& vDir, CPorta
 bool CPvsMgr::CheckPvsVolumnWall(const __Vector3& vOrig, const __Vector3& vDir, CPortalVol* pVolMy, e_WallType eWT)
 {
 	float ft, fu, fv;
-	int i;
+	int i = 0;
 
 	switch (eWT)
 	{

--- a/src/tool/N3Indoor/TransDummy.cpp
+++ b/src/tool/N3Indoor/TransDummy.cpp
@@ -80,8 +80,7 @@ void CTransDummy::InitDummyCube(int iType, __DUMMYCUBE* pDummyCube, __Vector3& v
 	pDummyCube->Vertices[30].Set(vCubeV[6], vCubeN[5], color);	pDummyCube->Vertices[31].Set(vCubeV[2], vCubeN[5], color);	pDummyCube->Vertices[32].Set(vCubeV[1], vCubeN[5], color);
 	pDummyCube->Vertices[33].Set(vCubeV[6], vCubeN[5], color);	pDummyCube->Vertices[34].Set(vCubeV[1], vCubeN[5], color);	pDummyCube->Vertices[35].Set(vCubeV[5], vCubeN[5], color);
 
-	int i;
-	for (i=0; i<NUM_CUBEVERTEX; ++i)
+	for (int i=0; i<NUM_CUBEVERTEX; ++i)
 	{
 		pDummyCube->Vertices[i].x += vOffset.x;
 		pDummyCube->Vertices[i].y += vOffset.y;
@@ -104,13 +103,12 @@ void CTransDummy::Tick()
 	ReCalcMatrix();
 
 	// 거리에 따라 정렬
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		__Vector3 vPos = m_DummyCubes[i].vCenterPos*m_Matrix;
 		m_DummyCubes[i].fDistance = (vPos - s_CameraData.vEye).Magnitude();
 	}
-	for (i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
+	for (int i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
 	qsort(m_pSortedCubes, sizeof(__DUMMYCUBE*), NUM_DUMMY, SortCube);
 }
 
@@ -154,8 +152,7 @@ void CTransDummy::Render()
 
 	// Cube 그리기
 	hr = s_lpD3DDev->SetFVF(FVF_XYZNORMALCOLOR);
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		ASSERT(m_pSortedCubes[i]);
 		hr = s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLELIST, 12, m_pSortedCubes[i]->Vertices, sizeof(__VertexXyzNormalColor));
@@ -200,10 +197,9 @@ __DUMMYCUBE* CTransDummy::Pick(int x, int y)
 	CPick pick;
 	pick.SetPickXY(x, y);
 
-	int i, j;
-	for (i=NUM_DUMMY-1; i>=0; --i)
+	for (int i=NUM_DUMMY-1; i>=0; --i)
 	{
-		for (j=0; j<12; ++j)
+		for (int j=0; j<12; ++j)
 		{
 			__Vector3 v1, v2, v3;
 			__VertexXyzNormalColor* pVertex;
@@ -379,11 +375,11 @@ void CTransDummy::GetPickRay(POINT point, __Vector3& vDir, __Vector3& vOrig)
 void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vector3* pvDiffScale)
 {
 	SelectElement se;
-	int i, iSize = m_SelObjArray.GetSize();
+	int iSize = m_SelObjArray.GetSize();
 	if (iSize<=0) return;
 	if (pvDiffPos)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			se = m_SelObjArray.GetAt(i);
 			switch (se.eST)
@@ -414,7 +410,7 @@ void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vec
 	}
 	if (pqDiffRot)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			se = m_SelObjArray.GetAt(i);
 			switch (se.eST)
@@ -435,7 +431,7 @@ void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vec
 	}
 	if (pvDiffScale)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			se = m_SelObjArray.GetAt(i);
 			switch (se.eST)

--- a/src/tool/N3ME/DTexGroupMng.cpp
+++ b/src/tool/N3ME/DTexGroupMng.cpp
@@ -116,7 +116,7 @@ void CDTexGroupMng::SetGroup(const char* pName)
 	it = m_Groups.begin();
 	iSize = m_Groups.size();
 	int* ArrayIdx = new int[iSize];
-	for(i = 0; i < iSize; i++, it++)
+	for(int i = 0; i < iSize; i++, it++)
 	{
 		CDTexGroup* pDTG = *it;
 		ArrayIdx[i] = pDTG->m_ID;
@@ -125,7 +125,7 @@ void CDTexGroupMng::SetGroup(const char* pName)
 	qsort( ArrayIdx, iSize, sizeof(int), this->CompareIdx );
 
 	int idx = 0;
-	for(i=0; i < iSize; i++)
+	for(int i=0; i < iSize; i++)
 	{
 		if(idx == ArrayIdx[i]) idx++;
 	}
@@ -392,10 +392,9 @@ bool CDTexGroupMng::LoadFromFile(CString RealFileName)
 		CProgressBar ProgressBar;
 		ProgressBar.Create("Load TileGroup Info..", 50,  iCount);
 
-		int i;
 		int id;
 		char szDTexGroupName[40];
-		for(i=0; i<iCount; i++)
+		for(int i=0; i<iCount; i++)
 		{
 			result = fscanf(stream, "%s %d\n", szDTexGroupName, &id);
 			//result = fscanf(stream, "%s", szDTexGroupName);

--- a/src/tool/N3ME/DTexMng.cpp
+++ b/src/tool/N3ME/DTexMng.cpp
@@ -208,14 +208,13 @@ void CDTexMng::LoadFromFile(CString RealFileName)
 		int id;
 
 		CDTexGroupMng* pDTexGroupMng = m_pMainFrm->GetDTexGroupMng();
-		int i;
 		char szDTexFileName[_MAX_PATH];
 		DWORD dwRWC;
 
 		CProgressBar ProgressBar;
 		ProgressBar.Create("Load TileTex Info..", 50,  iCount);
 
-		for(i=0;i<iCount;i++)
+		for(int i=0;i<iCount;i++)
 		{
 			ProgressBar.StepIt();
 
@@ -365,7 +364,6 @@ void CDTexMng::SaveGameTile()
 
 	HANDLE hFile;
 	int ix, iz;
-	int j;
 	char* pSourceImg;
 	char* pTargetImg;
 
@@ -416,7 +414,7 @@ void CDTexMng::SaveGameTile()
 					pSourceImg = (char*)((char*)d3dlr.pBits + (ix*Size*Bits) + (iz*Size*d3dlr.Pitch));
 					pTargetImg = (char*) d3dlrTarget.pBits;
 
-					for(j=0;j<Size;j++)
+					for(int j=0;j<Size;j++)
 					{
 						memcpy( &(pTargetImg[j*Bits*Size]), &(pSourceImg[j* d3dlr.Pitch]), Bits*Size);
 					}

--- a/src/tool/N3ME/DlgBase.cpp
+++ b/src/tool/N3ME/DlgBase.cpp
@@ -122,7 +122,6 @@ BOOL CDlgBase::OnInitDialog()
 	/////////////////////////////////////
 
 
-	int i = 0;
 	CString str, strTmp;
 
 	/////////////////////////////////////
@@ -159,7 +158,7 @@ D3DTOP_BUMPENVMAP|D3DTOP_BUMPENVMAPLUMINANCE|D3DTOP_DOTPRODUCT|D3DTOP_MULTIPLYAD
 	// Shape
 	m_CBShapePart.ResetContent();
 //	int nPartCount = 
-//	for(i = 0; i < nPartCount; i++) { strTmp.Format("%d", i); m_CBShapePart.AddString(strTmp); }
+//	for(int i = 0; i < nPartCount; i++) { strTmp.Format("%d", i); m_CBShapePart.AddString(strTmp); }
 //	m_CBShapePart.SetCurSel(0);
 
 	m_LPShape.AddPropItem("소속", "", PIT_EDIT, "");
@@ -200,7 +199,7 @@ D3DTOP_BUMPENVMAP|D3DTOP_BUMPENVMAPLUMINANCE|D3DTOP_DOTPRODUCT|D3DTOP_MULTIPLYAD
 	m_CBChrPart.SetCurSel(0);
 
 	m_CBChrLOD.ResetContent();
-	for(i = 0; i < MAX_CHR_LOD; i++) { strTmp.Format("LOD : %d", i); m_CBChrLOD.AddString(strTmp); }
+	for(int i = 0; i < MAX_CHR_LOD; i++) { strTmp.Format("LOD : %d", i); m_CBChrLOD.AddString(strTmp); }
 	m_CBChrLOD.SetCurSel(0);
 
 	m_LPCPart.AddPropItem("Part Type", "", PIT_COMBO, "머리카락|얼굴|상체|하체|손|발|??|");
@@ -605,7 +604,7 @@ void CDlgBase::UpdateInfo()
 		int nPlug = m_CBChrPlug.GetCurSel();
 		int nPlugCount = pC->PlugCount();
 		m_CBChrPlug.ResetContent();
-		for(i = 0; i < nPlugCount; i++)
+		for(int i = 0; i < nPlugCount; i++)
 		{
 			CString szTmp;
 			szTmp.Format("Plug : %d", i);

--- a/src/tool/N3ME/DlgDTexGroupView.cpp
+++ b/src/tool/N3ME/DlgDTexGroupView.cpp
@@ -65,10 +65,9 @@ void CDlgDTexGroupView::AddGroup(CDTexGroup *pGroup)
 	HTREEITEM hGroup = m_Tree.InsertItem(pGroup->m_Name, NULL);
 	m_Tree.SetItemData(hGroup,(DWORD)pGroup);
 
-	int i;
 	HTREEITEM hAttr;
 	CString Attr;
-	for(i=DTEX_FULL; i<DTEX_MAX; i++)
+	for(int i=DTEX_FULL; i<DTEX_MAX; i++)
 	{
 		//DTEX_FULL=0, DTEX_1PER2, DTEX_1PER4, DTEX_3PER4, DTEX_1PER8, DTEX_7PER8, DTEX_5PER8, DTEX_3PER8, DTEX_MAX=8
 		switch(i)

--- a/src/tool/N3ME/DlgMakeNPCPath.cpp
+++ b/src/tool/N3ME/DlgMakeNPCPath.cpp
@@ -374,6 +374,7 @@ void CDlgMakeNPCPath::OnBtnPathModify()
 
 	m_iSelNPCID = pPath->m_iNPCID;
 	
+	int i;
 	for(i=0;i<m_NPCList.GetCount(); i++)
 	{
 		int id = (int)m_NPCList.GetItemData(i);
@@ -392,7 +393,7 @@ void CDlgMakeNPCPath::OnBtnPathModify()
 
 	m_cSelAttrRegen = pPath->m_cAttr_Regen;
 
-	for(i=0;i<m_AttrRegenList.GetCount(); i++)
+	for(int i=0;i<m_AttrRegenList.GetCount(); i++)
 	{
 		unsigned char cId = (int)m_AttrRegenList.GetItemData(i);
 		if(cId==m_cSelAttrRegen)
@@ -404,7 +405,7 @@ void CDlgMakeNPCPath::OnBtnPathModify()
 
 	m_cSelAttrGroup = pPath->m_cAttr_Group;
 
-	for(i=0;i<m_AttrGroupList.GetCount(); i++)
+	for(int i=0;i<m_AttrGroupList.GetCount(); i++)
 	{
 		unsigned char cId = (int)m_AttrGroupList.GetItemData(i);
 		if(cId==m_cSelAttrGroup)
@@ -416,7 +417,7 @@ void CDlgMakeNPCPath::OnBtnPathModify()
 
 	m_cSelAttrCreate = pPath->m_cAttr_Create;
 
-	for(i=0;i<m_AttrCreateList.GetCount(); i++)
+	for(int i=0;i<m_AttrCreateList.GetCount(); i++)
 	{
 		unsigned char cId = (int)m_AttrCreateList.GetItemData(i);
 		if(cId==m_cSelAttrCreate)
@@ -428,7 +429,7 @@ void CDlgMakeNPCPath::OnBtnPathModify()
 
 	m_cSelOption = pPath->m_cAttr_Option;
 
-	for(i=0;i<m_OptionList.GetCount(); i++)
+	for(int i=0;i<m_OptionList.GetCount(); i++)
 	{
 		unsigned char cId = (int)m_OptionList.GetItemData(i);
 		if(cId==m_cSelOption)

--- a/src/tool/N3ME/DlgMapView.cpp
+++ b/src/tool/N3ME/DlgMapView.cpp
@@ -107,7 +107,7 @@ void CDlgMapView::OnPaint()
 			LineTo(dc,i,0);
 		}
 
-		for( i = 0; i < Map_View_Size/2 ; i+= Brush_Size)
+		for(int i = 0; i < Map_View_Size/2 ; i+= Brush_Size)
 		{
 			MoveToEx(dc,Map_View_Size/2,i,NULL);
 			LineTo(dc,0,i);

--- a/src/tool/N3ME/DlgSceneGraph.cpp
+++ b/src/tool/N3ME/DlgSceneGraph.cpp
@@ -99,28 +99,27 @@ void CDlgSceneGraph::UpdateTreeItem(HTREEITEM hParent, CN3Base *pBase)
 		str.Format("Scene : %s", m_pSceneRef->m_szName.c_str());
 		m_Tree.SetItemText(hItem, str);
 
-		int i = 0;
 		HTREEITEM hItem2 = NULL;
 
 		if (m_dwFlag & OBJ_CAMERA)
 		{
 			hItem2 = m_Tree.InsertItem("Camera", hItem);
 			int nCC = m_pSceneRef->CameraCount();
-			for(i = 0; i < nCC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->CameraGet(i));
+			for(int i = 0; i < nCC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->CameraGet(i));
 		}
 
 		if (m_dwFlag & OBJ_LIGHT)
 		{
 			hItem2 = m_Tree.InsertItem("Light", hItem);
 			int nLC = m_pSceneRef->LightCount();
-			for(i = 0; i < nLC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->LightGet(i));
+			for(int i = 0; i < nLC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->LightGet(i));
 		}
 		
 		if (m_dwFlag & OBJ_SHAPE)
 		{
 			hItem2 = m_Tree.InsertItem("Shape", hItem);
 			int nSC = m_pSceneRef->ShapeCount();
-			for(i = 0; i < nSC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->ShapeGet(i));
+			for(int i = 0; i < nSC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->ShapeGet(i));
 			m_Tree.SortChildren(hItem2);
 		}
 
@@ -128,28 +127,28 @@ void CDlgSceneGraph::UpdateTreeItem(HTREEITEM hParent, CN3Base *pBase)
 		{
 			hItem2 = m_Tree.InsertItem("Character", hItem);
 			int nCC2 = m_pSceneRef->ChrCount();
-			for(i = 0; i < nCC2; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->ChrGet(i));
+			for(int i = 0; i < nCC2; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->ChrGet(i));
 		}
 
 		if (m_dwFlag & OBJ_MESH)
 		{
 			hItem2 = m_Tree.InsertItem("Mesh Resource", hItem);
 			int nMC = m_pSceneRef->s_MngMesh.Count();
-			for(i = 0; i < nMC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->s_MngMesh.Get(i));
+			for(int i = 0; i < nMC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->s_MngMesh.Get(i));
 		}
 
 		if (m_dwFlag & OBJ_MESH_PROGRESSIVE)
 		{
 			hItem2 = m_Tree.InsertItem("Progressive Mesh Resource", hItem);
 			int nPMC = m_pSceneRef->s_MngPMesh.Count();
-			for(i = 0; i < nPMC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->s_MngPMesh.Get(i));
+			for(int i = 0; i < nPMC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->s_MngPMesh.Get(i));
 		}
 
 		if (m_dwFlag & OBJ_JOINT)
 		{
 			hItem2 = m_Tree.InsertItem("Joint Resource", hItem);
 			int nJC = m_pSceneRef->s_MngJoint.Count();
-			for(i = 0; i < nJC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->s_MngJoint.Get(i));
+			for(int i = 0; i < nJC; i++) this->UpdateTreeItem(hItem2, m_pSceneRef->s_MngJoint.Get(i));
 		}
 
 	}

--- a/src/tool/N3ME/DlgSetDTex.cpp
+++ b/src/tool/N3ME/DlgSetDTex.cpp
@@ -90,11 +90,10 @@ BOOL CDlgSetDTex::OnInitDialog()
 
 	m_TileSetName = pFrm->m_DTexInfoFileName;
 
-	int i;
 	int iSize = pDTexMng->m_pDTex.size();
 	it_DTex DTexIt = pDTexMng->m_pDTex.begin();
 	CDTex* pDTex;
-	for(i = 0; i<iSize; i++)
+	for(int i = 0; i<iSize; i++)
 	{
 		pDTex = (*DTexIt);
 		if(pDTex)
@@ -110,7 +109,7 @@ BOOL CDlgSetDTex::OnInitDialog()
 
 	it_DTexGroup it = pGroup->m_Groups.begin();
 	iSize = pGroup->m_Groups.size();
-	for(i = 0; i < iSize; i++, it++)
+	for(int i = 0; i < iSize; i++, it++)
 	{
 		CDTexGroup* pDTG = *it;
 		m_GroupList.InsertString(i, pDTG->m_Name);
@@ -138,7 +137,7 @@ BOOL CDlgSetDTex::OnInitDialog()
 	m_pGridVB->Lock(0,0, (VOID**)&pVerticesC, 0);
 
 	int GridInterval = (int)m_fTexSurfaceSize / NUM_DTEXTILE;
-	for(i=1;i<NUM_DTEXTILE;i++)
+	for(int i=1;i<NUM_DTEXTILE;i++)
 	{
 		int index = (i-1)*4;
 		pVerticesC[index].Set((float)((i*GridInterval)-1),	0.0f,							0.1f, 0.5f, 0xff800080);
@@ -668,11 +667,10 @@ void CDlgSetDTex::OnBtnLoadTileset()
 		//reset dialog box...
 		m_FileList.ResetContent();
 		m_GroupList.ResetContent();
-		int i;
 		int iSize = pDTexMng->m_pDTex.size();
 		it_DTex DTexIt = pDTexMng->m_pDTex.begin();
 		CDTex* pDTex;
-		for(i = 0; i<iSize; i++)
+		for(int i = 0; i<iSize; i++)
 		{
 			pDTex = (*DTexIt);
 			if(pDTex)
@@ -686,7 +684,7 @@ void CDlgSetDTex::OnBtnLoadTileset()
 
 		it_DTexGroup it = pDTexGroupMng->m_Groups.begin();
 		iSize = pDTexGroupMng->m_Groups.size();
-		for(i = 0; i < iSize; i++, it++)
+		for(int i = 0; i < iSize; i++, it++)
 		{
 			CDTexGroup* pDTG = *it;
 			m_GroupList.InsertString(i, pDTG->m_Name);

--- a/src/tool/N3ME/DlgSetSound.cpp
+++ b/src/tool/N3ME/DlgSetSound.cpp
@@ -114,7 +114,8 @@ int CDlgSetSound::MakeIdx()
 	for(int i=m_iIdx_Min; i<=m_iIdx_Max;i++)
 	{
 		int cnt = m_ListSoundGroup.GetCount();
-		for(int j=0;j<cnt;j++)
+		int j;
+		for(j=0;j<cnt;j++)
 		{
 			pSoundInfo = (LPSOUNDINFO)m_ListSoundGroup.GetItemDataPtr(j);
 			if(pSoundInfo->dwID == i) break;

--- a/src/tool/N3ME/DlgShapeList.cpp
+++ b/src/tool/N3ME/DlgShapeList.cpp
@@ -191,7 +191,7 @@ void CDlgShapeList::OnBtnSort()
 	m_ListShape.ResetContent();
 
 	SMIter it = Map.begin();
-	for(i=0;i<cnt;i++)
+	for(int i=0;i<cnt;i++)
 	{
 		std::string str = (*it).first;
 		CN3Shape* pShape = (*it).second;

--- a/src/tool/N3ME/DlgUnusedFiles.cpp
+++ b/src/tool/N3ME/DlgUnusedFiles.cpp
@@ -91,7 +91,7 @@ void CDlgUnusedFiles::UpdateAll()
 	}
 
 	iFNC = m_InvalidFileNames.GetSize();
-	for(i = 0; i < iFNC; i++)
+	for(int i = 0; i < iFNC; i++)
 	{
 		m_ListInvalidObjects.AddString(m_InvalidFileNames[i]);
 	}

--- a/src/tool/N3ME/EventMgr.cpp
+++ b/src/tool/N3ME/EventMgr.cpp
@@ -408,7 +408,7 @@ void CEventMgr::SaveInfoTextFile(char* szEvent)
 			for(int i=0;i<5;i++)
 				fscanf(stream, "\t%s", &pEvent->m_Con[i]);
 
-			for(i=0;i<5;i++)
+			for(int i=0;i<5;i++)
 				fscanf(stream, "\t%s", &pEvent->m_Exe[i]);
 
 			fscanf(stream, "\n");
@@ -444,7 +444,7 @@ void CEventMgr::SaveInfoTextFile(char* szEvent)
 			for(int i=0;i<5;i++)
 				fprintf(stream, "\t%s", pEvent->m_Con[i]);
 
-			for(i=0;i<5;i++)
+			for(int i=0;i<5;i++)
 				fprintf(stream, "\t%s", pEvent->m_Exe[i]);
 
 			fprintf(stream, "\n");
@@ -462,7 +462,7 @@ void CEventMgr::SaveInfoTextFile(char* szEvent)
 			for(int i=0;i<5;i++)
 				fprintf(stream, "\t%s", pEvent->m_Con[i]);
 
-			for(i=0;i<5;i++)
+			for(int i=0;i<5;i++)
 				fprintf(stream, "\t%s", pEvent->m_Exe[i]);
 
 			fprintf(stream, "\n");
@@ -492,7 +492,7 @@ void CEventMgr::SaveInfoTextFile(char* szEvent)
 			for(int i=0;i<5;i++)
 				fprintf(stream, "\t%s", pEvent->m_Con[i]);
 
-			for(i=0;i<5;i++)
+			for(int i=0;i<5;i++)
 				fprintf(stream, "\t%s", pEvent->m_Exe[i]);
 
 			fprintf(stream, "\n");

--- a/src/tool/N3ME/LyTerrain.cpp
+++ b/src/tool/N3ME/LyTerrain.cpp
@@ -257,14 +257,13 @@ void CLyTerrain::Release()
 		m_pDlgSetLightMap = NULL;
 	}
 
-	int x,z;
 	if(m_pColorTexture)
 	{
-		for(x=0;x<m_iNumColorMap;x++)
+		for(int x=0;x<m_iNumColorMap;x++)
 		{
 			if(m_pColorTexture[x])
 			{
-//				for(z=0;z<m_iNumColorMap;z++) // 굳이 이렇게 안해도 다 지워진다...
+//				for(int z=0;z<m_iNumColorMap;z++) // 굳이 이렇게 안해도 다 지워진다...
 //				{
 //					m_pColorTexture[x][z].Release();
 //				}
@@ -276,12 +275,11 @@ void CLyTerrain::Release()
 		m_pColorTexture = NULL;
 	}
 
-	int i;
 	if(m_ppLightMapTexture)
 	{
-		for(x=0;x<m_iHeightMapSize;x++)
+		for(int x=0;x<m_iHeightMapSize;x++)
 		{
-			for(z=0;z<m_iHeightMapSize;z++)
+			for(int z=0;z<m_iHeightMapSize;z++)
 			{
 				if(m_ppLightMapTexture[x][z])
 				{
@@ -324,7 +322,7 @@ void CLyTerrain::Release()
 	
 	if(m_ppMapData)
 	{
-		for(i=0;i<m_iHeightMapSize;i++)
+		for(int i=0;i<m_iHeightMapSize;i++)
 		{
 			delete[] m_ppMapData[i];
 			m_ppMapData[i] = NULL;
@@ -335,7 +333,7 @@ void CLyTerrain::Release()
 
 	if(m_ppRenderInfo)
 	{
-		for(i=0;i<m_iHeightMapSize;i++)
+		for(int i=0;i<m_iHeightMapSize;i++)
 		{
 			delete [] m_ppRenderInfo[i];
 			m_ppRenderInfo[i] = NULL;
@@ -346,7 +344,7 @@ void CLyTerrain::Release()
 
 	if(m_ppIsLightMap)
 	{
-		for(i=0;i<m_iHeightMapSize;i++)
+		for(int i=0;i<m_iHeightMapSize;i++)
 		{
 			delete [] m_ppIsLightMap[i];
 			m_ppIsLightMap[i] = NULL;
@@ -406,17 +404,16 @@ void CLyTerrain::Init(int HeightMapSize)
 	if( ((m_iHeightMapSize-1) * m_iColorMapPixelPerUnitDistance) % m_iColorMapTexSize == 0 ) m_iNumColorMap--;
 	
 	m_pColorTexture = new CN3Texture*[m_iNumColorMap];
-	int x,z;
-	for(x=0; x<m_iNumColorMap; x++)
+	for(int x=0; x<m_iNumColorMap; x++)
 	{
 		m_pColorTexture[x] = new CN3Texture[m_iNumColorMap];
 	}
 	
 	//D3DLOCKED_RECT d3dlr;
 	
-	for(x=0;x<m_iNumColorMap;x++)
+	for(int x=0;x<m_iNumColorMap;x++)
 	{
-		for(z=0;z<m_iNumColorMap;z++)
+		for(int z=0;z<m_iNumColorMap;z++)
 		{
 			m_pColorTexture[x][z].Create(m_iColorMapTexSize, m_iColorMapTexSize, D3DFMT_X8R8G8B8, TRUE);
 			/*
@@ -437,8 +434,7 @@ void CLyTerrain::Init(int HeightMapSize)
 	m_ppIsLightMap = new bool*[m_iHeightMapSize];
 	m_ppLightMapTexture = new CN3Texture**[m_iHeightMapSize];
 	
-	int i;		
-	for(i=0;i<m_iHeightMapSize;i++)
+	for(int i=0;i<m_iHeightMapSize;i++)
 	{
 		m_ppMapData[i] = new MAPDATA[m_iHeightMapSize];
 		m_ppRenderInfo[i] = new BOOL[m_iHeightMapSize];
@@ -446,9 +442,9 @@ void CLyTerrain::Init(int HeightMapSize)
 		m_ppLightMapTexture[i] = new CN3Texture*[m_iHeightMapSize];
 	}
 
-	for(x=0;x<m_iHeightMapSize;x++)
+	for(int x=0;x<m_iHeightMapSize;x++)
 	{
-		for(z=0;z<m_iHeightMapSize;z++)
+		for(int z=0;z<m_iHeightMapSize;z++)
 		{
 			m_ppIsLightMap[x][z] = false;
 			m_ppLightMapTexture[x][z] = NULL;
@@ -1372,10 +1368,8 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	///////////////////////
 	// 데이타 재구성...
 	//
-	int x,z;
 	short tmpTexIdx;
 	short tmpTileIdx;
-	int i;
 	int TTCount;
 	///////////////////////
 
@@ -1383,11 +1377,11 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	ProgressBar.Create("Analyze TileMap...", 50,  m_iHeightMapSize);
 
 	TexTree.clear();
-	for(x=0; x<m_iHeightMapSize-1;x++)
+	for(int x=0; x<m_iHeightMapSize-1;x++)
 	{
 		ProgressBar.StepIt();
 
-		for(z=0; z<m_iHeightMapSize-1;z++)
+		for(int z=0; z<m_iHeightMapSize-1;z++)
 		{
 			tmpTexIdx = (m_ppMapData[x][z].DTexInfo1.TexIdx.TexID * NUM_DTEXTILE) + m_ppMapData[x][z].DTexInfo1.TexIdx.TileY;
 			tmpTileIdx = m_ppMapData[x][z].DTexInfo1.TexIdx.TileX;
@@ -1396,6 +1390,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 			{
 				TTIt = TexTree.lower_bound(tmpTexIdx);
 				TTCount = TexTree.count(tmpTexIdx);
+				int i;
 				for(i=0;i<TTCount; i++)
 				{
 					if((*TTIt).second==tmpTileIdx) break;
@@ -1411,6 +1406,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 			{
 				TTIt = TexTree.lower_bound(tmpTexIdx);
 				TTCount = TexTree.count(tmpTexIdx);
+				int i;
 				for(i=0;i<TTCount; i++)
 				{
 					if((*TTIt).second==tmpTileIdx) break;
@@ -1433,7 +1429,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 			NumTileSrcTex++;
 			TileList.push_back((*TTIt).first);
 			TTCount = TexTree.count((*TTIt).first);
-			for(i=0;i<TTCount;i++) TTIt++;
+			for(int i=0;i<TTCount;i++) TTIt++;
 		}
 	}
 
@@ -1450,11 +1446,11 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	__ASSERT(hAlloc, "Global allocation failed.");
 	GAMEMAPDATA* pGMDs = (GAMEMAPDATA*)GlobalLock(hAlloc);
 	ProgressBar.Create("Writing TileMap...", 50, m_iHeightMapSize);
-	for(x=0; x<m_iHeightMapSize;x++)
+	for(int x=0; x<m_iHeightMapSize;x++)
 	{
 		ProgressBar.StepIt();
 
-		for(z=0; z<m_iHeightMapSize;z++)
+		for(int z=0; z<m_iHeightMapSize;z++)
 		{
 			GAMEMAPDATA* pGMD = &pGMDs[x*m_iHeightMapSize+z];
 
@@ -1466,7 +1462,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 			pGMD->Tex2Dir = (char)m_ppMapData[x][z].DTexInfo2.Dir;
 
 			TTIt = TexTree.begin();
-			for(i=0;i<NumTile;i++)
+			for(int i=0;i<NumTile;i++)
 			{
 				tmpTexIdx = (*TTIt).first;
 				tmpTileIdx = (*TTIt).second;
@@ -1501,9 +1497,9 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	float re_XZCrossHalfDistPow2 = pow((re_HalfDist * 1.4141592f),2);
 	int sx, sz;
 	float height;
-	for(x=0; x<pat_HeightMapSize; x++)
+	for(int x=0; x<pat_HeightMapSize; x++)
 	{
-		for(z=0; z<pat_HeightMapSize; z++)
+		for(int z=0; z<pat_HeightMapSize; z++)
 		{
 			sx = x * ti_PatchSize;
 			sz = z * ti_PatchSize;
@@ -1532,7 +1528,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	ZeroMemory(SeedAttr, sizeof(unsigned char)*m_iHeightMapSize*m_iHeightMapSize);
 	CDlgSowSeed* pSowSeed = pFrm->m_pDlgSowSeed;
 
-	for( i = 0 ; i < m_iHeightMapSize*m_iHeightMapSize ; i++)
+	for(int i = 0 ; i < m_iHeightMapSize*m_iHeightMapSize ; i++)
 	{
 		SeedAttr[i].Obj_Id = 0;
 		SeedAttr[i].Seed_Count = 0;
@@ -1542,7 +1538,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	int size = pFrm->GetMapMng()->m_SowSeedMng.Grass_Group.size();
 	it_Grass_Group it = pFrm->GetMapMng()->m_SowSeedMng.Grass_Group.begin();
 	int temp_Id = 0;
-	for( i = 0 ; i < size ; i++,it++)
+	for(int i = 0 ; i < size ; i++,it++)
 	{
 		LPGRASS_GROUP group = (LPGRASS_GROUP)*it;
 		it_Grass it_grass = group->grass.begin();
@@ -1594,7 +1590,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 			}
 		}
 	}
-	for( i = 0 ; i < m_iHeightMapSize*m_iHeightMapSize ; i++)
+	for(int  i = 0 ; i < m_iHeightMapSize*m_iHeightMapSize ; i++)
 	{
 		WriteFile(hFile,&SeedAttr[i],sizeof(unsigned char),&dwRWC,NULL);
 		if( SeedAttr[i].SeedGroup_Sub != NULL)
@@ -1605,9 +1601,9 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 
 /*   원래의 풀 저장 
 	int NumSeedInfo = pFrm->m_SeedGroupList.size();
-	for(x=0; x<m_iHeightMapSize-1;x++)
+	for(int x=0; x<m_iHeightMapSize-1;x++)
 	{
-		for(z=0; z<m_iHeightMapSize-1;z++)
+		for(int z=0; z<m_iHeightMapSize-1;z++)
 		{
 			int Group = m_ppMapData[x][z].DTexInfo1.Attr.Group;
 
@@ -1635,9 +1631,9 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 
 	// 텍스트파일로 함 뽑아보자..
 	FILE* stream = fopen("c:\\grass.txt", "w");
-	for(z=0; z<m_iHeightMapSize;z++)
+	for(int z=0; z<m_iHeightMapSize;z++)
 	{
-		for(x=0; x<m_iHeightMapSize;x++)
+		for(int x=0; x<m_iHeightMapSize;x++)
 		{
 			SEEDGROUP v = SeedAttr[z + (x*m_iHeightMapSize)];
 			fprintf(stream, "%d,%d\t",v.Obj_Id,v.Seed_Count );
@@ -1665,7 +1661,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 		// Tile Map Resource
 		LLIter TLIt = TileList.begin();
 		CN3Texture* pTexture;
-		for(i=0;i<NumTileSrcTex;i++)
+		for(int i=0;i<NumTileSrcTex;i++)
 		{
 			int TexIdx = (*TLIt) / NUM_DTEXTILE;
 			int YIdx = (*TLIt) % NUM_DTEXTILE;
@@ -1684,7 +1680,7 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 
 		int SrcIdx, TileIdx;
 		TTIt = TexTree.begin();
-		for(i=0;i<NumTile;i++)
+		for(int i=0;i<NumTile;i++)
 		{
 			SrcIdx = 0;
 			for(TLIt=TileList.begin();TLIt!=TileList.end();TLIt++)
@@ -1716,9 +1712,9 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 		ProgressBar.Create("Save Light Map Data", 50, m_iNumLightMap);	
 		
 		short sx, sz;
-		for(z=0;z<m_iHeightMapSize;z++)
+		for(int z=0;z<m_iHeightMapSize;z++)
 		{
-			for(x=0;x<m_iHeightMapSize;x++)
+			for(int x=0;x<m_iHeightMapSize;x++)
 			{
 				if(m_ppIsLightMap[x][z]==false) continue;
 
@@ -2222,9 +2218,6 @@ void CLyTerrain::SetVisibleRect()
 	m_VisibleRect.left = m_VisibleRect.right = tx;
 	m_VisibleRect.top = m_VisibleRect.bottom = tz;
 
-	int i;
-
-
 	// 사면체의 법선 벡터와 Far 네 귀퉁이 위치 계산..
 	float fS = sinf(CN3Base::s_CameraData.fFOV / 2.0f);
 	float fPL = CN3Base::s_CameraData.fFP;
@@ -2236,7 +2229,7 @@ void CLyTerrain::SetVisibleRect()
 							__Vector3(fPL * fS * fAspect, fPL * -fS, fPL),	// RightBottom
 							__Vector3(fPL * -fS * fAspect, fPL * -fS, fPL) }; // LeftBottom
 
-	for(i=0;i<4;i++)
+	for(int i=0;i<4;i++)
 	{
 		// 귀퉁이 위치에 회전 행렬을 적용한다..
 		vFPs[i] = vFPs[i] * CN3Base::s_CameraData.mtxViewInverse;
@@ -2970,15 +2963,13 @@ bool CLyTerrain::Pick(int x, int y, __Vector3* vec, POINT* pHeightMapPos)
 //
 int CLyTerrain::DetectRealLightMap(int sx, int sz, int range)
 {
-	int x,z;
-	//int i;
 	bool bIsEmpty;
 	D3DLOCKED_RECT d3dlrt;
 	
 	int NumLightMap = 0;
-	for(x=sx;x<(sx+range);x++)
+	for(int x=sx;x<(sx+range);x++)
 	{
-		for(z=sz;z<(sz+range);z++)
+		for(int z=sz;z<(sz+range);z++)
 		{
 			if(m_ppIsLightMap[x][z]==false) continue;
 			if(!m_ppLightMapTexture[x][z]) continue;
@@ -3005,7 +2996,7 @@ int CLyTerrain::DetectRealLightMap(int sx, int sz, int range)
 				}
 			}
 /*	외각테두리 없는거..
-			for(i=0; i<LIGHTMAP_TEX_SIZE*LIGHTMAP_TEX_SIZE; i++)
+			for(int i=0; i<LIGHTMAP_TEX_SIZE*LIGHTMAP_TEX_SIZE; i++)
 			{
 				if(pImg[i]!=0xffffffff)
 				{
@@ -4523,7 +4514,6 @@ void CLyTerrain::UpdateBrushIntensityMap(int iShape, int iSize, float fFallOff)
 {
 	ASSERT(fFallOff>=0.0f && iSize>0);
 	ZeroMemory(m_fBrushIntensityMap, sizeof(m_fBrushIntensityMap));
-	int i, j, k;
 
 	int iStart, iEnd, iHalfRadius;
 	iStart = BRUSH_CENTER-(int)(iSize/2);	iEnd = iStart+iSize;	iHalfRadius = (iSize/2)+1;
@@ -4532,8 +4522,8 @@ void CLyTerrain::UpdateBrushIntensityMap(int iShape, int iSize, float fFallOff)
 	{
 		if (iSize%2)		// Brush 사이즈가 홀수일때
 		{
-			for(i=iStart; i<iEnd; ++i)
-				for(j=iStart; j<iEnd; ++j)
+			for(int i=iStart; i<iEnd; ++i)
+				for(int j=iStart; j<iEnd; ++j)
 				{
 					{
 						int iTmpX = i-BRUSH_CENTER, iTmpY = j-BRUSH_CENTER;
@@ -4547,8 +4537,8 @@ void CLyTerrain::UpdateBrushIntensityMap(int iShape, int iSize, float fFallOff)
 		else				// Brush 사이즈가 짝수일때
 		{
 			float fTmp = (iHalfRadius-0.5f);
-			for(i=iStart; i<iEnd; ++i)
-				for(j=iStart; j<iEnd; ++j)
+			for(int i=iStart; i<iEnd; ++i)
+				for(int j=iStart; j<iEnd; ++j)
 				{
 					float fTmpX = i-BRUSH_CENTER+0.5f, fTmpY = j-BRUSH_CENTER+0.5f;
 					float fLen = fTmpX*fTmpX + fTmpY*fTmpY;
@@ -4565,13 +4555,13 @@ void CLyTerrain::UpdateBrushIntensityMap(int iShape, int iSize, float fFallOff)
 
 		if (iSize%2)		// Brush 사이즈가 홀수일때
 		{
-			for (i=0; i <= iSize/2; ++i) fIntensity[i] = GetFallOffValue(fFallOff, float(i)/iHalfRadius);
+			for (int i=0; i <= iSize/2; ++i) fIntensity[i] = GetFallOffValue(fFallOff, float(i)/iHalfRadius);
 
-			for(i=iStart; i<iEnd; ++i)
-				for(j=iStart; j<iEnd; ++j)
+			for(int i=iStart; i<iEnd; ++i)
+				for(int j=iStart; j<iEnd; ++j)
 				{
 					int iOffsetX = abs(i-BRUSH_CENTER),iOffsetZ = abs(j-BRUSH_CENTER);
-					for (k=0; k<iHalfRadius; ++k)
+					for (int k=0; k<iHalfRadius; ++k)
 					{
 						if ((iOffsetX==k && iOffsetZ<=k) || (iOffsetX<=k && iOffsetZ==k) )
 							m_fBrushIntensityMap[i][j] = fIntensity[k];
@@ -4580,34 +4570,34 @@ void CLyTerrain::UpdateBrushIntensityMap(int iShape, int iSize, float fFallOff)
 		}
 		else				// Brush 사이즈가 짝수일때
 		{
-			for (i=0; i <= iSize/2; ++i) fIntensity[i] = GetFallOffValue(fFallOff, float(i+0.5f)/(iHalfRadius));
+			for (int i=0; i <= iSize/2; ++i) fIntensity[i] = GetFallOffValue(fFallOff, float(i+0.5f)/(iHalfRadius));
 
-			for(i=iStart; i<iEnd; ++i)
+			for(int i=iStart; i<iEnd; ++i)
 			{
 				int iT = 2*iStart+iSize-i;
 				if (BRUSH_CENTER>i)
 				{
-					for(j=i; j<iT; ++j)	m_fBrushIntensityMap[i][j] = fIntensity[BRUSH_CENTER-1-i];
+					for(int j=i; j<iT; ++j)	m_fBrushIntensityMap[i][j] = fIntensity[BRUSH_CENTER-1-i];
 				}
 				else
 				{
-					for(j=iT-1; j<=i; ++j)
+					for(int j=iT-1; j<=i; ++j)
 					{
 						ASSERT(i-BRUSH_CENTER>=0);
 						m_fBrushIntensityMap[i][j] = fIntensity[i-BRUSH_CENTER];
 					}
 				}
 			}
-			for(i=iStart; i<iEnd; ++i)
+			for(int i=iStart; i<iEnd; ++i)
 			{
 				int iT = 2*iStart+iSize-i;
 				if (BRUSH_CENTER>i)
 				{
-					for(j=i+1; j<iT-1; ++j)	m_fBrushIntensityMap[j][i] = fIntensity[BRUSH_CENTER-1-i];
+					for(int j=i+1; j<iT-1; ++j)	m_fBrushIntensityMap[j][i] = fIntensity[BRUSH_CENTER-1-i];
 				}
 				else
 				{
-					for(j=iT; j<i; ++j)
+					for(int j=iT; j<i; ++j)
 					{
 						ASSERT(i-BRUSH_CENTER>=0);
 						m_fBrushIntensityMap[j][i] = fIntensity[i-BRUSH_CENTER];
@@ -4636,15 +4626,13 @@ float CLyTerrain::GetFallOffValue(float fFallOff, float x)
 //
 void CLyTerrain::Heighten(POINT ptCenter, float fHeight)
 {
-	int i, j;
-
 	float fNewHeight = FLT_MAX;
 
 	float fMax = -FLT_MIN;
 	float fMin = FLT_MIN;
-	for (i=0; i<MAX_BRUSH_SIZE; ++i)
+	for (int i=0; i<MAX_BRUSH_SIZE; ++i)
 	{
-		for (j=0; j<MAX_BRUSH_SIZE; ++j)
+		for (int j=0; j<MAX_BRUSH_SIZE; ++j)
 		{
 			int iMapX, iMapZ;
 			iMapX = ptCenter.x - BRUSH_CENTER + i;
@@ -4658,9 +4646,9 @@ void CLyTerrain::Heighten(POINT ptCenter, float fHeight)
 		if(fNewHeight != FLT_MAX) break;
 	}
 
-	for (i=0; i<MAX_BRUSH_SIZE; ++i)
+	for (int i=0; i<MAX_BRUSH_SIZE; ++i)
 	{
-		for (j=0; j<MAX_BRUSH_SIZE; ++j)
+		for (int j=0; j<MAX_BRUSH_SIZE; ++j)
 		{
 			int iMapX, iMapZ;
 			iMapX = ptCenter.x - BRUSH_CENTER + i;
@@ -4683,11 +4671,10 @@ void CLyTerrain::Heighten(POINT ptCenter, float fHeight)
 //
 void CLyTerrain::Flaten(POINT ptCenter)
 {	
-	int i, j;
 	// 새로운 값과 기존 높이값을 차이를 계산해서 버퍼에 저장.
-	for (i=0; i<MAX_BRUSH_SIZE; ++i)
+	for (int i=0; i<MAX_BRUSH_SIZE; ++i)
 	{
-		for (j=0; j<MAX_BRUSH_SIZE; ++j)
+		for (int j=0; j<MAX_BRUSH_SIZE; ++j)
 		{
 			int iMapX, iMapZ;
 			iMapX = ptCenter.x - BRUSH_CENTER + i;
@@ -4718,11 +4705,10 @@ void CLyTerrain::Smooth(POINT ptCenter)
 										{2,3,4,3,2},
 										{1,2,3,2,1}};
 
-	int i, j, k, l;
 	// 새로운 값과 기존 높이값을 차이를 계산해서 버퍼에 저장.
-	for (i=0; i<MAX_BRUSH_SIZE; ++i)
+	for (int i=0; i<MAX_BRUSH_SIZE; ++i)
 	{
-		for (j=0; j<MAX_BRUSH_SIZE; ++j)
+		for (int j=0; j<MAX_BRUSH_SIZE; ++j)
 		{
 			int iMapX, iMapZ;
 			iMapX = ptCenter.x - BRUSH_CENTER + i;
@@ -4733,8 +4719,8 @@ void CLyTerrain::Smooth(POINT ptCenter)
 			{
 				float fH;
 				float fSumWeight = 0.0f;
-				for (k=0; k<iWSize; ++k)
-					for (l=0; l<iWSize; ++l)
+				for (int k=0; k<iWSize; ++k)
+					for (int l=0; l<iWSize; ++l)
 					{
 						fH = GetApexHeight(iMapX+k-iHalfWSize, iMapZ+l-iHalfWSize);
 						if (fH != -FLT_MAX)
@@ -4749,9 +4735,9 @@ void CLyTerrain::Smooth(POINT ptCenter)
 	}
 
 	// 버퍼에 있는 값을 m_fBrushIntensityMap 적용하여 높이값 수정
-	for (i=0; i<MAX_BRUSH_SIZE; ++i)
+	for (int i=0; i<MAX_BRUSH_SIZE; ++i)
 	{
-		for (j=0; j<MAX_BRUSH_SIZE; ++j)
+		for (int j=0; j<MAX_BRUSH_SIZE; ++j)
 		{
 			int iMapX, iMapZ;
 			iMapX = ptCenter.x - BRUSH_CENTER + i;
@@ -4771,11 +4757,10 @@ void CLyTerrain::UpdateBrushArea(POINT ptCenter)
 {
 	m_iBrushIndexCount = 0;
 	int iBrushVerexCount = 0;
-	int i, j;
 	float fOffsetY = 0.05f;
-	for (i=0; i<MAX_BRUSH_SIZE; ++i)
+	for (int i=0; i<MAX_BRUSH_SIZE; ++i)
 	{
-		for (j=0; j<MAX_BRUSH_SIZE; ++j)
+		for (int j=0; j<MAX_BRUSH_SIZE; ++j)
 		{
 			if (m_fBrushIntensityMap[i][j] == 0.0f) continue;
 

--- a/src/tool/N3ME/MapMng.cpp
+++ b/src/tool/N3ME/MapMng.cpp
@@ -353,9 +353,9 @@ void CMapMng::DeleteSelObjectFromOutputScene()
 		return;
 //	}
 
-	int i, iSize = m_SelOutputObjArray.GetSize();
+	int iSize = m_SelOutputObjArray.GetSize();
 	if (iSize == 0) return;
-	for (i=0; i<iSize; ++i)
+	for (int i=0; i<iSize; ++i)
 	{
 		CN3Transform* pSelObj = m_SelOutputObjArray.GetAt(i);
 		if (pSelObj == NULL) continue;
@@ -598,8 +598,8 @@ void CMapMng::Render()
 	if (m_pTerrain) m_pTerrain->Render();
 	if (m_pSceneOutput && !m_bHideObj) m_pSceneOutput->Render();
 
-	int i, iSize = m_SelOutputObjArray.GetSize();
-	for (i=0; i<iSize; ++i)
+	int iSize = m_SelOutputObjArray.GetSize();
+	for (int i=0; i<iSize; ++i)
 	{
 		CN3Transform* pSelObj = m_SelOutputObjArray.GetAt(i);
 		if (pSelObj == NULL) continue;
@@ -1035,9 +1035,8 @@ BOOL CMapMng::MouseMsgFilter(LPMSG pMsg)
 				__Vector3 vPos;
 				CN3Transform* pDestObj = NULL;
 
-				int j,iSize = m_SelOutputObjArray.GetSize();
-				
-				for(j=0;j<iSize;++j)
+				int iSize = m_SelOutputObjArray.GetSize();
+				for(int j=0;j<iSize;++j)
 				{
 					pDestObj = m_SelOutputObjArray.GetAt(j);
 					if(pDestObj==NULL) continue;
@@ -1169,7 +1168,7 @@ CN3Base* CMapMng::Pick(POINT point, int* pnPart)	// Object Picking...
 	CN3Chr* pChr;
 	CN3Mesh* pMesh;
 	int nCC = m_pSceneOutput->ChrCount();
-	for(i = 0; i < nCC; i++)
+	for(int i = 0; i < nCC; i++)
 	{
 		pChr = m_pSceneOutput->ChrGet(i);
 		_ASSERT(pChr);
@@ -1197,7 +1196,7 @@ CN3Base* CMapMng::Pick(POINT point, int* pnPart)	// Object Picking...
 
 	int nPart = -1;
 	__Vector3 vI;
-	for(i = 0; i < nSortCount; i++)
+	for(int i = 0; i < nSortCount; i++)
 	{
 //		bIntersect = pick.PickByBox(sort[i].vMin, sort[i].vMax, vI);
 		nPart = sort[i].pObj->CheckCollisionPrecisely(true, point.x, point.y);
@@ -1291,8 +1290,8 @@ void CMapMng::SelectObjectByDragRect(RECT* pRect, BOOL bAdd)
 
 	D3DVIEWPORT9 vp = pEng->s_CameraData.vp;
 
-	int i, iSC = m_pSceneOutput->ShapeCount();
-	for (i=0; i<iSC;)
+	int iSC = m_pSceneOutput->ShapeCount();
+	for (int i=0; i<iSC;)
 	{
 		CN3TransformCollision*	pObj = m_pSceneOutput->ShapeGet(i);
 		D3DXVECTOR4 v;
@@ -1475,7 +1474,7 @@ void CMapMng::MakeServerDataFiles(LPCTSTR lpszPathName)
 	//
 	DWORD dwNum;
 	int iEventObjectCount = 0; // 먼저 갯수를 세고..
-	for(i = 0; i < nSC; i++)
+	for(int i = 0; i < nSC; i++)
 	{
 		CN3Shape* pShape = m_pSceneOutput->ShapeGet(i);
 		if(pShape->m_iEventID || pShape->m_iEventType || pShape->m_iNPC_ID || pShape->m_iNPC_Status ) // 이벤트가 있으면
@@ -1483,7 +1482,7 @@ void CMapMng::MakeServerDataFiles(LPCTSTR lpszPathName)
 	}
 
 	WriteFile(hFile, &iEventObjectCount, 4, &dwNum, NULL);
-	for(i = 0; i < nSC; i++)
+	for(int i = 0; i < nSC; i++)
 	{
 		CN3Shape* pShape = m_pSceneOutput->ShapeGet(i);
 		short sEvent = 0; __Vector3 vPos;
@@ -1869,8 +1868,8 @@ void CMapMng::Invalidate()
 void CMapMng::DropSelObjToTerrain()
 {// 선택한 객체를 지형에 붙인다.(Y값만 조정)
 	if (m_pTerrain == NULL) return;
-	int i, iSize = m_SelOutputObjArray.GetSize();
-	for (i=0; i<iSize; ++i)
+	int iSize = m_SelOutputObjArray.GetSize();
+	for (int i=0; i<iSize; ++i)
 	{
 		CN3Transform* pSelObj = m_SelOutputObjArray.GetAt(i);
 		ASSERT(pSelObj);
@@ -1939,15 +1938,15 @@ void CMapMng::RenderGrid(float fGridSize, float fMaxDistance)	// fGridSize크기로
 	if (fGridSize != fPrevGridSize || fMaxDistance != fPrevMaxDistance)
 	{
 		fPrevGridSize = fGridSize;		fPrevMaxDistance = fMaxDistance;
-		int i, iCount = (int)(fMaxDistance/fGridSize);
+		int iCount = (int)(fMaxDistance/fGridSize);
 		const D3DCOLOR color = 0xff00ff00;
 		iVC=0;
-		for (i=0; i<iCount; ++i)
+		for (int i=0; i<iCount; ++i)
 		{
 			pVertices[iVC++].Set(i*fGridSize, 0, 0, color);
 			pVertices[iVC++].Set(i*fGridSize, 0, fMaxDistance, color);
 		}
-		for (i=0; i<iCount; ++i)
+		for (int i=0; i<iCount; ++i)
 		{
 			pVertices[iVC++].Set(0, 0, i*fGridSize, color);
 			pVertices[iVC++].Set(fMaxDistance, 0, i*fGridSize, color);
@@ -1995,10 +1994,10 @@ void CMapMng::SaveObjectPostData(LPCTSTR lpszFileName)
 	char szDrive[_MAX_DRIVE], szDir[_MAX_DIR], szFName[_MAX_FNAME], szExt[_MAX_EXT];
 	_splitpath(lpszFileName, szDrive, szDir, szFName, szExt);
 
-	int i, iSC = m_pSceneOutput->ShapeCount();
+	int iSC = m_pSceneOutput->ShapeCount();
 	fprintf(stream, "Shape Count : %d\n", iSC);
 
-	for(i=0; i<iSC; ++i)
+	for(int i=0; i<iSC; ++i)
 	{
 		CN3Shape* pShape = m_pSceneOutput->ShapeGet(i);
 		ASSERT(pShape);
@@ -2033,11 +2032,11 @@ void CMapMng::SaveObjectPostData(LPCTSTR lpszFileName)
 	char szDrive[_MAX_DRIVE], szDir[_MAX_DIR], szFName[_MAX_FNAME], szExt[_MAX_EXT];
 	_splitpath(lpszFileName, szDrive, szDir, szFName, szExt); // 파일 이름과 확장자만 갖고..
 
-	int i, iSC = m_pSceneOutput->ShapeCount();
+	int iSC = m_pSceneOutput->ShapeCount();
 	fprintf(stream, "Shape Post Count : %d\n", iSC);
 
 	char szSFN[MAX_PATH] = "";
-	for(i=0; i<iSC; ++i)
+	for(int i=0; i<iSC; ++i)
 	{
 		CN3Shape* pShape = m_pSceneOutput->ShapeGet(i);
 
@@ -2087,7 +2086,7 @@ void CMapMng::SaveObjectPostDataPartition(LPCTSTR lpszFileName, float psx, float
 	float ex = sx + width;
 	float ez = sz + width;
 
-	int i, iSC = m_pSceneOutput->ShapeCount();
+	int iSC = m_pSceneOutput->ShapeCount();
 
 	std::list<int> ShapeList;
 	ShapeList.clear();
@@ -2095,7 +2094,7 @@ void CMapMng::SaveObjectPostDataPartition(LPCTSTR lpszFileName, float psx, float
 	CProgressBar ProgressBar;
 	ProgressBar.Create("Pick out Objects.", 50, iSC);
 
-	for(i=0; i<iSC; ++i)
+	for(int i=0; i<iSC; ++i)
 	{
 		ProgressBar.StepIt();
 		CN3Shape* pShape = m_pSceneOutput->ShapeGet(i);
@@ -2198,12 +2197,12 @@ void CMapMng::LoadObjectPostData(LPCTSTR lpszFileName)
 	}
 	else // 새로 만든 데이터이다..
 	{
-		int i = 0, iSC = 0;
+		int iSC = 0;
 		sscanf(szFirstLine, "Shape Post Count : %d\n", &iSC);
 
 		char szSFN[MAX_PATH] = "", szSFN2[MAX_PATH] = "";
 		char szLine[1024] = "";
-		for(i=0; i<iSC; ++i)
+		for(int i=0; i<iSC; ++i)
 		{
 			CN3Shape* pShape = new CN3Shape();
 			m_pSceneOutput->ShapeAdd(pShape); // 추가..
@@ -2282,12 +2281,12 @@ void CMapMng::ImportPostDataFromScene(const char *szFileName)
 	ReadFile(hFile, &fFrmStart, 4, &dwRWC, NULL); // 전체 프레임.
 	ReadFile(hFile, &fFrmEnd, 4, &dwRWC, NULL); // 전체 프레임.
 
-	int i = 0, nL = 0;
+	int nL = 0;
 	char szName[512] = "";
 
 	int nCC = 0;
 	ReadFile(hFile, &nCC, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < nCC; i++)
+	for(int i = 0; i < nCC; i++)
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -2298,7 +2297,7 @@ void CMapMng::ImportPostDataFromScene(const char *szFileName)
 
 	int nLC = 0;
 	ReadFile(hFile, &nLC, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < nLC; i++) 
+	for(int i = 0; i < nLC; i++) 
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -2309,7 +2308,7 @@ void CMapMng::ImportPostDataFromScene(const char *szFileName)
 
 	int nSC = 0;
 	ReadFile(hFile, &nSC, 4, &dwRWC, NULL); // Shapes..
-	for(i = 0; i < nSC; i++)
+	for(int i = 0; i < nSC; i++)
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -2323,7 +2322,7 @@ void CMapMng::ImportPostDataFromScene(const char *szFileName)
 
 	int nChrC = 0;
 	ReadFile(hFile, &nChrC, 4, &dwRWC, NULL); // 캐릭터
-	for(i = 0; i < nChrC; i++)
+	for(int i = 0; i < nChrC; i++)
 	{
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL <= 0) continue;
@@ -2471,13 +2470,13 @@ void CMapMng::DeleteUnusedFiles()
 	// 파일 지우기 대화상자 띄우기..
 	CDlgUnusedFiles dlg;
 	int iUFC = unusedFNs.size();
-	for(i = 0; i < iUFC; i++)
+	for(int i = 0; i < iUFC; i++)
 	{
 		dlg.m_FileNames.Add(unusedFNs[i].c_str());
 	}
 
 	int iIFC = invalidFNs.size();
-	for(i = 0; i < iIFC; i++)
+	for(int i = 0; i < iIFC; i++)
 	{
 		dlg.m_InvalidFileNames.Add(invalidFNs[i].c_str());
 	}
@@ -2521,7 +2520,7 @@ void CMapMng::DeleteOverlappedObjects() // 위치가 겹친 젝트를 찾는다.
 	}
 
 	iSC = OverlappedObjects.size();
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		m_pSceneOutput->ShapeDelete(OverlappedObjects[i]); // 겹친거 지우기..
 	}
@@ -2550,7 +2549,7 @@ void CMapMng::DeleteSelectedSourceObjects()
 	}
 
 	iSC = SameObjects.size();
-	for(i = 0; i < iSC; i++)
+	for(int i = 0; i < iSC; i++)
 	{
 		m_pSceneOutput->ShapeDelete(SameObjects[i]); // 겹친거 지우기..
 	}
@@ -2624,8 +2623,8 @@ void CMapMng::SetEditState(ENUM_EDIT_STATE eEditStat)
 
 			//	선택한 것들을 백업하고
 			CN3Transform* pDestObj = NULL;
-			int j, iSize = m_SelOutputObjArray.GetSize();
-			for(j=0;j<iSize;++j)
+			int iSize = m_SelOutputObjArray.GetSize();
+			for(int j=0;j<iSize;++j)
 			{
 				pDestObj = m_SelOutputObjArray.GetAt(j);
 				if(pDestObj==NULL) continue;
@@ -2645,9 +2644,7 @@ void CMapMng::SetEditState(ENUM_EDIT_STATE eEditStat)
 			{
 				CN3Transform* pDestObj = NULL, *pNewObj=NULL;
 				__Vector3 vNewPos,vObjPos;
-				int j, iSize;
-
-				iSize = m_SelOutputObjBack.GetSize();
+				int iSize = m_SelOutputObjBack.GetSize();
 				if(iSize==0) return;	
 
 				//	찍을 새로운위치를 입력
@@ -2665,7 +2662,7 @@ void CMapMng::SetEditState(ENUM_EDIT_STATE eEditStat)
 				}
 
 				m_SelOutputObjArray.RemoveAll();	//	기존 선택된 정보를 지우고
-				for(j=0;j<iSize;++j)
+				for(int j=0;j<iSize;++j)
 				{
 					pDestObj = m_SelOutputObjBack.GetAt(j);	//	백업된 데이터를 찾는다
 					if(pDestObj==NULL) continue;

--- a/src/tool/N3ME/N3ME.vcxproj
+++ b/src/tool/N3ME/N3ME.vcxproj
@@ -63,7 +63,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -97,7 +96,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/N3ME/PondMesh.cpp
+++ b/src/tool/N3ME/PondMesh.cpp
@@ -177,10 +177,9 @@ void CPondMesh::RenderVertexPoint()	// 잘보이게 점만 다시 그리기
 	D3DCOLOR clr = D3DCOLOR_ARGB(0xff, 0xff, 0x00, 0x00);
 	s_lpD3DDev->SetFVF(FVF_TRANSFORMEDCOLOR);
 
-	int i;
 	D3DXVECTOR4 v;
 	//	화면상에 빨간점
-	for (i=0; i<=m_iVC; ++i)
+	for (int i=0; i<=m_iVC; ++i)
 	{
 		D3DXVec3Transform(&v, (D3DXVECTOR3*)(&(m_pViewVts[i])), &matVP);
 
@@ -203,7 +202,7 @@ void CPondMesh::RenderVertexPoint()	// 잘보이게 점만 다시 그리기
 	}
 
 	//	영역을 나타내는 점
-	for(i=0;i<m_iRectVC;++i)
+	for(int i=0;i<m_iRectVC;++i)
 	{
 		D3DXVec3Transform(&v, (D3DXVECTOR3*)(&(m_pRectVts[i])), &matVP);
 
@@ -384,15 +383,14 @@ void CPondMesh::MakeIndex()
 		m_pdwIndex = new WORD [m_iWaterScaleWidth*m_iWaterScaleHeight*6];
 	}
 
-	int j,k;
 	int m = m_iWaterScaleWidth;	//	다음줄
 	int x=0,y=m;
 	WORD* indexPtr = m_pdwIndex;	//	삼각형을 부를 위치 설정
 
 	--m;
-	for (j=0; j<m_iWaterScaleHeight; j++)
+	for (int j=0; j<m_iWaterScaleHeight; j++)
 	{
-		for (k=0; k<m; k++)
+		for (int k=0; k<m; k++)
 		{
 			indexPtr[0] = x;
 			indexPtr[1] = x+1;
@@ -415,20 +413,19 @@ void CPondMesh::ReCalcUV()
 	if (m_iVC<2) return;
 
 	const float fTu = m_fTU,fTv = m_fTV;
-	int i,j;
 
 	__Vector3* pVertices= m_pVertices;
 	__VertexXyzT2* ptmpVertices = m_pViewVts;
 	
 	//	줄에 대한 변경(x,z에 대해)
-	for (i=0;i<m_iWaterScaleHeight;++i)
+	for (int i=0;i<m_iWaterScaleHeight;++i)
 	{	
 		ptmpVertices->tu = ptmpVertices->x/fTu;
 		ptmpVertices->tv = ptmpVertices->z/fTv;
 		ptmpVertices->tu2 = ptmpVertices->tu;
 		ptmpVertices->tv2 = ptmpVertices->tv;			
 
-		for (j=0;j<m_iWaterScaleWidth;++j)
+		for (int j=0;j<m_iWaterScaleWidth;++j)
 		{	
 			(ptmpVertices+j)->tu = (ptmpVertices+j)->x/fTu;
 			(ptmpVertices+j)->tv = (ptmpVertices+j)->z/fTv;
@@ -458,7 +455,7 @@ void CPondMesh::ReCalcVexUV()
 	
 	MakePondPos();
 
-	for(i=0;i<m_iVC;++i)
+	for(int i=0;i<m_iVC;++i)
 	{
 		m_pVertices[i].x  = pBakVertices[i].x;
 		m_pVertices[i].y  = pBakVertices[i].y;
@@ -620,18 +617,17 @@ void CPondMesh::CalcuWidth(int iSx,int iSy,int iEx,int iEy)
 	//	----------------------------------------------------------------------------------
 
 	//	새로운 좌표 계산
-	int iIntervalNum,j;
 	float fx1,fx2,fnx1,fnx2;
 	float fny1,fny2;
 	float ftemp;
 	
 	//	----------------------------------------------------------------------------------
-	iIntervalNum = iSx-1;	//	좌우 각 한점씩 빼기에
+	int iIntervalNum = iSx-1;	//	좌우 각 한점씩 빼기에
 	if(iIntervalNum>0)
 	{
 		++pLRVertices, ++pLRViewVer;	//	오른쪽
 		fny2 = vNowPick.z-vBakPick.z;
-		for(j=0 ; j<iIntervalNum ; ++j,++pLRVertices,++pLRViewVer,++pvTop,++pvBottom)
+		for(int j=0 ; j<iIntervalNum ; ++j,++pLRVertices,++pLRViewVer,++pvTop,++pvBottom)
 		{
 			// 사이의 점마다 거리비율을 구해 새로운 위치를 구한다
 			fx2 = pvRight->x - vBakPick.x;	//	좌우의 비율구함
@@ -659,7 +655,7 @@ void CPondMesh::CalcuWidth(int iSx,int iSy,int iEx,int iEy)
 	{
 		++pLRVertices, ++pLRViewVer;	//	왼쪽
 		fny2 = vNowPick.z-vBakPick.z;
-		for(j=0 ; j<iIntervalNum ; ++j,++pLRVertices,++pLRViewVer,++pvTop,++pvBottom)
+		for(int j=0 ; j<iIntervalNum ; ++j,++pLRVertices,++pLRViewVer,++pvTop,++pvBottom)
 		{
 			fx2 = vBakPick.x - pvLeft->x;
 			if(fx2!=0)
@@ -678,7 +674,7 @@ void CPondMesh::CalcuWidth(int iSx,int iSy,int iEx,int iEy)
 	}
 	//	----------------------------------------------------------------------------------
 
-	for(j=0;j<m_iWaterScaleWidth;++j)
+	for(int j=0;j<m_iWaterScaleWidth;++j)
 		SetAllPos(j,iSy,iEx,iEy);
 }
 
@@ -698,12 +694,11 @@ void CPondMesh::SetAllPos(int iSx,int iSy,int iEx,int iEy)
 	vNowCenter = *(m_pViewVts + m_iWaterScaleWidth*iSy + iSx);	//	백업된 전의 좌표(참조하여 새로운 좌표 계산)
 
 	//	새로운 좌표 계산
-	int iIntervalNum,j;
 	float fy1,fy2,fny1,fny2;
 	float fnx1,fnx2;
 	float ftemp;
 
-	iIntervalNum = iSy-1;
+	int iIntervalNum = iSy-1;
 	if(iIntervalNum>0)
 	{
 		fy2 = vCenter.z - vTop.z;
@@ -712,7 +707,7 @@ void CPondMesh::SetAllPos(int iSx,int iSy,int iEx,int iEy)
 			pTBVertices += m_iWaterScaleWidth, pTBViewVer += m_iWaterScaleWidth;
 			fnx2 = vNowCenter.x - vCenter.x;
 			fny2 = vTop.z - vNowCenter.z;
-			for(j=0 ; j<iIntervalNum ; ++j,pTBVertices+=m_iWaterScaleWidth,pTBViewVer+=m_iWaterScaleWidth)
+			for(int j=0 ; j<iIntervalNum ; ++j,pTBVertices+=m_iWaterScaleWidth,pTBViewVer+=m_iWaterScaleWidth)
 			{
 				fy1 = pTBVertices->z - vTop.z; 	//	좌우의 비율구함
 				ftemp = fy1/fy2;
@@ -735,7 +730,7 @@ void CPondMesh::SetAllPos(int iSx,int iSy,int iEx,int iEy)
 			pTBVertices += m_iWaterScaleWidth, pTBViewVer += m_iWaterScaleWidth;
 			fnx2 = vNowCenter.x - vCenter.x;
 			fny2 = vNowCenter.z - vBottom.z;
-			for(j=0 ; j<iIntervalNum ; ++j,pTBVertices+=m_iWaterScaleWidth,pTBViewVer+=m_iWaterScaleWidth)
+			for(int j=0 ; j<iIntervalNum ; ++j,pTBVertices+=m_iWaterScaleWidth,pTBViewVer+=m_iWaterScaleWidth)
 			{
 				fy1 = vBottom.z - pTBVertices->z; 
 				ftemp = fy1/fy2;
@@ -857,7 +852,7 @@ bool CPondMesh::Load1000(HANDLE hFile)
 
 	//	---------------------------------------------------------------------------------------------------------
 	for(int i=0;i<4;++i) m_vDrawBox[i] = m_pVertices[0];
-	for(i=0;i<m_iVC;++i)
+	for(int i=0;i<m_iVC;++i)
 	{
 		m_pViewVts[i].x = m_pVertices[i].x , m_pViewVts[i].y = m_pVertices[i].y , m_pViewVts[i].z = m_pVertices[i].z;
 
@@ -918,7 +913,7 @@ bool CPondMesh::Load(HANDLE hFile)
 
 	//	---------------------------------------------------------------------------------------------------------
 	for(int i=0;i<4;++i) m_vDrawBox[i] = m_pVertices[0];
-	for(i=0;i<m_iVC;++i)
+	for(int i=0;i<m_iVC;++i)
 	{
 		if(m_vDrawBox[0].x < m_pVertices[i].x) m_vDrawBox[0].x = m_pVertices[i].x,m_vDrawBox[3].x = m_pVertices[i].x;
 		if(m_vDrawBox[1].x > m_pVertices[i].x) m_vDrawBox[1].x = m_pVertices[i].x,m_vDrawBox[2].x = m_pVertices[i].x;
@@ -1000,13 +995,12 @@ void CPondMesh::SetVtx()
 	float tempX = m_fWaterScaleX;
 	float tempZ = m_fWaterScaleZ;
 
-	int i,j;
 	int iNumVertex = m_iVC/m_iWaterScaleWidth;
 
 	//	 처음 한 줄에 대해 x방향만 변함
 	pVtx->Set(pViewVtx->x,pViewVtx->y,pViewVtx->z);
 
-	for (j=1;j<m_iWaterScaleWidth;j++)
+	for (int j=1;j<m_iWaterScaleWidth;j++)
 	{	
 		(pVtx+j)->x = (pVtx+j-1)->x + ((pViewVtx+j)->x-(pViewVtx+j-1)->x) / tempX;
 		(pVtx+j)->y = (pViewVtx+j)->y;
@@ -1016,13 +1010,13 @@ void CPondMesh::SetVtx()
 	pViewVtx += m_iWaterScaleWidth;
 	
 	//	줄에 대한 x,z에 대한 변환
-	for(i = 1 ;i<iNumVertex ; i++)
+	for(int i = 1 ;i<iNumVertex ; i++)
 	{
 		pVtx->x = (pVtx-m_iWaterScaleWidth)->x + (pViewVtx->x-(pViewVtx-m_iWaterScaleWidth)->x) / tempX;
 		pVtx->y = pViewVtx->y;
 		pVtx->z = (pVtx-m_iWaterScaleWidth)->z + (pViewVtx->z-(pViewVtx-m_iWaterScaleWidth)->z) / tempZ;
 
-		for (j=1;j<m_iWaterScaleWidth;j++)
+		for (int j=1;j<m_iWaterScaleWidth;j++)
 		{	
 			(pVtx+j)->x = (pVtx+j-1)->x + ((pViewVtx+j)->x-(pViewVtx+j-1)->x) / tempX;
 			(pVtx+j)->y = (pViewVtx+j)->y;
@@ -1157,11 +1151,11 @@ int CPondMesh::AddVertex()
 int CPondMesh::DeleteVertex(int iIndex)
 {
 	if (iIndex<0 || iIndex>=m_iVC) return m_iVC;
-	int i, iStart;
+	int iStart;
 	iStart = (iIndex/m_iLastVertexNum);
 
 	// Vertext Buffer delete
-	for (i=iStart*m_iLastVertexNum; i<m_iVC-m_iLastVertexNum; ++i)
+	for (int i=iStart*m_iLastVertexNum; i<m_iVC-m_iLastVertexNum; ++i)
 	{
 		m_pVertices[i] = m_pVertices[i+m_iLastVertexNum];
 		m_pViewVts[i] = m_pViewVts[i+m_iLastVertexNum];

--- a/src/tool/N3ME/PondMng.cpp
+++ b/src/tool/N3ME/PondMng.cpp
@@ -70,8 +70,8 @@ void CPondMng::MainInvalidate()
 void CPondMng::SelPondDelete(CPondMesh* pPondMesh)
 {
 	it_PondMesh it = m_pSelPonds.begin();
-	int iSize = m_pSelPonds.size();
-	for(int i = 0; i < iSize; i++, it++)
+	int i, iSize = m_pSelPonds.size();
+	for(i = 0; i < iSize; i++, it++)
 	{
 		CPondMesh* pRM = *it;
 		if(pRM == pPondMesh)
@@ -123,11 +123,11 @@ bool CPondMng::Load(HANDLE hFile)
 	int iVersion;
 	ReadFile(hFile, &iVersion, sizeof(iVersion), &dwNum,NULL);	//	GetVersion
 
-	int i, iPondMeshCount;
+	int iPondMeshCount;
 	if(iVersion==1001)
 	{
 		ReadFile(hFile, &iPondMeshCount, sizeof(iPondMeshCount), &dwNum, NULL);
-		for (i=0; i<iPondMeshCount; ++i)
+		for (int i=0; i<iPondMeshCount; ++i)
 		{
 			CPondMesh* pPondMesh = new CPondMesh;
 			pPondMesh->Load1001(hFile);
@@ -137,7 +137,7 @@ bool CPondMng::Load(HANDLE hFile)
 	else if(iVersion==1000)
 	{
 		ReadFile(hFile, &iPondMeshCount, sizeof(iPondMeshCount), &dwNum, NULL);
-		for (i=0; i<iPondMeshCount; ++i)
+		for (int i=0; i<iPondMeshCount; ++i)
 		{
 			CPondMesh* pPondMesh = new CPondMesh;
 			pPondMesh->Load1000(hFile);
@@ -147,7 +147,7 @@ bool CPondMng::Load(HANDLE hFile)
 	else
 	{
 		iPondMeshCount = iVersion;
-		for (i=0; i<iPondMeshCount; ++i)
+		for (int i=0; i<iPondMeshCount; ++i)
 		{
 			CPondMesh* pPondMesh = new CPondMesh;
 			pPondMesh->Load(hFile);
@@ -746,14 +746,13 @@ BOOL CPondMng::SelectVtxByDragRect(RECT* pRect, BOOL bAdd,BOOL bSelectPond)
 	CPondMesh* pSelPond=NULL;
 	int iSize = m_pSelPonds.size();
 	it_PondMesh it = m_pSelPonds.begin();
-	int i,k;
-	for(i = 0; i < iSize; ++i, ++it) 	// 이미 선택된 연못이 있다면..
+	for(int i = 0; i < iSize; ++i, ++it) 	// 이미 선택된 연못이 있다면..
 	{
 		pSelPond= *it;
 		if(pSelPond==NULL) continue;
 
 		int iVC = pSelPond->VertexCount();	// 그연못의 점 숫자를 구하기
-		for (k=0; k<iVC;++k)
+		for (int k=0; k<iVC;++k)
 		{
 			__VertexXyzT2* pVtx = pSelPond->GetVertex(k);	// 점 하나 구하기
 			if (pVtx == NULL) continue;
@@ -799,15 +798,15 @@ BOOL CPondMng::SelectVtxByDragRect(RECT* pRect, BOOL bAdd,BOOL bSelectPond)
 		it = m_PondMeshes.begin();
 		iSize = m_PondMeshes.size();
 		BOOL bChkSamePond;
-		for(i = 0; i < iSize; ++i, ++it)
+		for(int i = 0; i < iSize; ++i, ++it)
 		{
 			CPondMesh* pRM = *it;
 			if (pRM == NULL) continue;
 
-			int j, iVC = pRM->VertexCount();				// 이연못의 점 갯수
+			int iVC = pRM->VertexCount();				// 이연못의 점 갯수
 			pSelPond = NULL;
 			bChkSamePond=TRUE;
-			for (j=0; j<iVC; ++j)
+			for (int j=0; j<iVC; ++j)
 			{
 				__VertexXyzT2* pVtx = pRM->GetVertex(j);	// 점 하나 구하기
 				if (pVtx == NULL) continue;
@@ -845,7 +844,7 @@ BOOL CPondMng::SelectVtxByDragRect(RECT* pRect, BOOL bAdd,BOOL bSelectPond)
 	else
 	{
 		m_VtxPosDummy.SetSelVtx(m_SelVtxArray.GetAt(0));
-		for (i=1; i<iSize; ++i)
+		for (int i=1; i<iSize; ++i)
 		{
 			m_VtxPosDummy.AddSelVtx(m_SelVtxArray.GetAt(i));
 		}
@@ -1004,7 +1003,7 @@ void CPondMng::SetVtxCenter()	//	연못(들)의 중간점을 찾아 세팅,예전 스케일도 백�
 	{
 		float Stx,Enx,Stz,Enz;
 		Stx=Enx=pvCenter[0].x, Stz=Enz= pvCenter[0].z;
-		for(i=0;i<nCenterCnt;i++)
+		for(int i=0;i<nCenterCnt;i++)
 		{
 			if(Stx>pvCenter[i].x) Stx  = pvCenter[i].x;
 			if(Enx<pvCenter[i].x) Enx  = pvCenter[i].x;

--- a/src/tool/N3ME/QTNode.cpp
+++ b/src/tool/N3ME/QTNode.cpp
@@ -25,8 +25,7 @@ CQTNode::CQTNode()
 	m_Level = 0;
 	m_State = QTNODESTATE_NOTRENDER;
 
-	int i;
-	for(i=0;i<DIR_NUM;i++)
+	for(int i=0;i<DIR_NUM;i++)
 	{
 		m_pFriend[i] = NULL;
 		m_pChild[i] = NULL;
@@ -59,12 +58,10 @@ void CQTNode::Init(int level, CLyTerrain* pTerrain)
 	m_Level = level;
 	m_State = QTNODESTATE_NOTRENDER;
 
-	int i;
-
 	// 자식노드만들기..
 	if(level != m_pRefTerrain->m_iMaxLevel)
 	{
-		for(i=0;i<DIR_NUM;i++)
+		for(int i=0;i<DIR_NUM;i++)
 		{
 			m_pChild[i] = new CQTNode;
 			m_pChild[i]->Init(level+1, pTerrain);
@@ -72,7 +69,7 @@ void CQTNode::Init(int level, CLyTerrain* pTerrain)
 	}
 	else if(level == m_pRefTerrain->m_iMaxLevel)
 	{
-		for(i=0;i<DIR_NUM;i++)
+		for(int i=0;i<DIR_NUM;i++)
 		{
 			m_pChild[i] = NULL;
 		}
@@ -216,8 +213,7 @@ void CQTNode::SetMinMaxY()
 	}
 
 	//젤 마지막 노드가 아닐때...
-	int i;
-	for(i=0;i<DIR_NUM;i++)
+	for(int i=0;i<DIR_NUM;i++)
 	{
 		if(!m_pChild[i]) continue;
 		m_pChild[i]->SetMinMaxY();
@@ -233,8 +229,7 @@ void CQTNode::SetMinMaxY()
 //
 void CQTNode::ClearMinMaxY()
 {
-	int i;
-	for(i=0;i<DIR_NUM;i++)
+	for(int i=0;i<DIR_NUM;i++)
 	{
 		if(!m_pChild[i]) continue;
 		m_pChild[i]->ClearMinMaxY();
@@ -249,8 +244,7 @@ void CQTNode::ClearMinMaxY()
 //
 void CQTNode::SetWholeClipped()
 {
-	int i;
-	for(i=0;i<DIR_NUM;i++)
+	for(int i=0;i<DIR_NUM;i++)
 	{
 		if(!m_pChild[i]) continue;
 		m_pChild[i]->SetWholeClipped();
@@ -286,8 +280,7 @@ void CQTNode::Tick()
 	}
 
 	//내려가는 경우..	
-	int i;
-	for(i=0;i<DIR_NUM;i++)
+	for(int i=0;i<DIR_NUM;i++)
 	{
 		if(!m_pChild[i]) continue;
 		m_pChild[i]->Tick();
@@ -402,9 +395,7 @@ void CQTNode::RenderMaxLevel()
 	hr = m_pRefTerrain->s_lpD3DDev->GetTextureStageState( 1, D3DTSS_COLORARG1, &ColorArg21);
 	hr = m_pRefTerrain->s_lpD3DDev->GetTextureStageState( 1, D3DTSS_COLORARG2, &ColorArg22);
 
-	int cx,cz;
-	int i;
-	
+	int cx,cz;	
 	int dir1, dir2;
 	float u1, u2, v1, v2;
 	int tmpTIdx;
@@ -423,7 +414,7 @@ void CQTNode::RenderMaxLevel()
 	//
 
 
-	for(i=0;i<2;i++)
+	for(int i=0;i<2;i++)
 	{
 		int idx = i<<2;
 		if(i==1) { cx++; cz++; }
@@ -555,7 +546,7 @@ void CQTNode::RenderMaxLevel()
 
 	cx = m_CenterX-1;
 	cz = m_CenterZ;
-	for(i=0;i<2;i++)
+	for(int i=0;i<2;i++)
 	{
 		int idx = (i<<2) + 8;
 		if(i==1) { cx++; cz--; }
@@ -707,7 +698,7 @@ void CQTNode::RenderMaxLevel()
 	int tx, tz;
 
 	DWORD COP2 = D3DTOP_ADD;
-	for(i=0;i<4;i++)
+	for(int i=0;i<4;i++)
 	{
 		COP2 = D3DTOP_ADD;
 		tx = m_CenterX;
@@ -821,7 +812,7 @@ void CQTNode::RenderMaxLevel()
 	hr = m_pRefTerrain->s_lpD3DDev->SetRenderState( D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
 	hr = m_pRefTerrain->s_lpD3DDev->SetRenderState( D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
 	
-	for(i=0;i<NumLightMapUse;i++)
+	for(int i=0;i<NumLightMapUse;i++)
 	{
 		m_pRefTerrain->s_lpD3DDev->SetTexture( 0, pRefLightMapTex[i]->Get());
 		hr = m_pRefTerrain->s_lpD3DDev->DrawPrimitive( D3DPT_TRIANGLEFAN, (i<<2), 2);
@@ -848,13 +839,12 @@ void CQTNode::RenderMaxLevel()
 	m_pRefTerrain->m_TileVB->Lock( 0, 0, (VOID**)&pVertices, 0 );
 
 	int cx,cz;
-	int i;
 	cx = m_CenterX;
 	cz = m_CenterZ;
 
 	int dir1, dir2;
 	float u1, u2, v1, v2;
-	for(i=0;i<2;i++)
+	for(int i=0;i<2;i++)
 	{
 		int idx = i<<2;
 		if(i==1) { cx++; cz++; }
@@ -887,7 +877,7 @@ void CQTNode::RenderMaxLevel()
 	}
 	cx = m_CenterX;
 	cz = m_CenterZ;
-	for(i=0;i<2;i++)
+	for(int i=0;i<2;i++)
 	{
 		int idx = (i<<2) + 8;
 		if(i==1) { cx++; cz--; }
@@ -945,7 +935,7 @@ void CQTNode::RenderMaxLevel()
 	hr = m_pRefTerrain->s_lpD3DDev->SetTextureStageState( 1, D3DTSS_COLORARG2, D3DTA_CURRENT);
 
 	int tx, tz;	
-	for(i=0;i<4;i++)
+	for(int i=0;i<4;i++)
 	{
 		tx = m_CenterX;
 		tz = m_CenterZ;

--- a/src/tool/N3ME/RiverMesh.cpp
+++ b/src/tool/N3ME/RiverMesh.cpp
@@ -60,9 +60,8 @@ void CRiverMesh::Release()
 
 void CRiverMesh::ReleaseAnimTextures()
 {
-	int i;
 	if (m_pAnimTextures == NULL) {m_iAnimTextureCount = 0; return;}
-	for (i=0; i<m_iAnimTextureCount; ++i)
+	for (int i=0; i<m_iAnimTextureCount; ++i)
 	{
 		if (m_pAnimTextures[i]) {s_MngTex.Delete(&(m_pAnimTextures[i])); m_pAnimTextures[i] = NULL;}
 	}
@@ -104,8 +103,7 @@ bool CRiverMesh::Load(HANDLE hFile)
 
 	if (m_iAnimTextureCount>0) m_pAnimTextures = new CN3Texture*[m_iAnimTextureCount];
 
-	int i;
-	for (i=0; i<m_iAnimTextureCount; ++i)
+	for (int i=0; i<m_iAnimTextureCount; ++i)
 	{
 		ReadFile(hFile, &iLen, sizeof(iLen), &dwNum, NULL);	// texture name length
 		if (iLen <=0) { m_pAnimTextures[i] = NULL; __ASSERT(0, "텍스쳐가 없다"); continue;}
@@ -145,8 +143,7 @@ bool CRiverMesh::Save(HANDLE hFile)
 	WriteFile(hFile, &m_fAnimTexFPS, sizeof(m_fAnimTexFPS), &dwNum, NULL);	// Anim Tex frame/sec
 	WriteFile(hFile, &m_iAnimTextureCount, sizeof(m_iAnimTextureCount), &dwNum, NULL);	// AnimTexture Count
 
-	int i;
-	for (i=0; i<m_iAnimTextureCount; ++i)
+	for (int i=0; i<m_iAnimTextureCount; ++i)
 	{
 		__ASSERT(m_pAnimTextures[i], "강물 텍스쳐 포인터가 NULL입니다.");
 		int iLen = m_pAnimTextures[i]->FileName().size();
@@ -277,8 +274,7 @@ void CRiverMesh::RenderVertexPoint()	// 잘보이게 점만 다시 그리기
 	D3DCOLOR clr = D3DCOLOR_ARGB(0xff, 0xff, 0x00, 0x00);
 	s_lpD3DDev->SetFVF(FVF_TRANSFORMEDCOLOR);
 
-	int i;
-	for (i=0; i<m_iVC; ++i)
+	for (int i=0; i<m_iVC; ++i)
 	{
 		D3DXVECTOR4 v;
 		D3DXVec3Transform(&v, &(m_pVertices[i]), &matVP);
@@ -362,11 +358,10 @@ int CRiverMesh::AddVertex()
 int CRiverMesh::DeleteVertex(int iIndex)
 {
 	if (iIndex<0 || iIndex>=m_iVC) return m_iVC;
-	int i, iStart;
-	iStart = (iIndex/4);
+	int iStart = (iIndex/4);
 
 	// Vertext Buffer delete
-	for (i=iStart*4; i<m_iVC-4; ++i)
+	for (int i=iStart*4; i<m_iVC-4; ++i)
 	{
 		m_pVertices[i] = m_pVertices[i+4];
 	}
@@ -398,8 +393,7 @@ BOOL CRiverMesh::SetAnimTextureName(LPCTSTR pszFName, LPCTSTR pszExt, int iCount
 	m_pAnimTextures = new CN3Texture*[m_iAnimTextureCount];
 
 	char szTemp[_MAX_PATH];
-	int i;
-	for (i=0; i<m_iAnimTextureCount; ++i)
+	for (int i=0; i<m_iAnimTextureCount; ++i)
 	{
 		wsprintf(szTemp, "%s%02d%s", pszFName, i, pszExt);
 		m_pAnimTextures[i] = s_MngTex.Get(szTemp);
@@ -428,7 +422,7 @@ void CRiverMesh::ReCalcUV()
 	}
 
 /*
-	int i, iCount = m_iVC/2;
+	int iCount = m_iVC/2;
 	float fUPerMeter = 1.0f/m_fMeterPerU;
 	float fVPerMeter = 1.0f/m_fMeterPerV;
 	float fUPerMeter2 = 1.0f/m_fMeterPerU2;
@@ -445,7 +439,7 @@ void CRiverMesh::ReCalcUV()
 	m_pVertices[0].tv2 = 0.0f;			m_pVertices[1].tv2 = 0.0f;
 
 	// 나머지 점 계산하기
-	for (i=1; i<iCount; ++i)
+	for (int i=1; i<iCount; ++i)
 	{
 		// U
 		vDiff = (__Vector3)m_pVertices[i*2+0].v - (__Vector3)m_pVertices[i*2+1].v;

--- a/src/tool/N3ME/RiverMng.cpp
+++ b/src/tool/N3ME/RiverMng.cpp
@@ -63,9 +63,9 @@ bool CRiverMng::Load(HANDLE hFile)
 	Release();
 
 	DWORD dwNum;
-	int i, iRiverMeshCount;
+	int iRiverMeshCount;
 	ReadFile(hFile, &iRiverMeshCount, sizeof(iRiverMeshCount), &dwNum, NULL);
-	for (i=0; i<iRiverMeshCount; ++i)
+	for (int i=0; i<iRiverMeshCount; ++i)
 	{
 		CRiverMesh* pRvrMesh = new CRiverMesh;
 		pRvrMesh->Load(hFile);
@@ -478,11 +478,10 @@ void CRiverMng::SelectVtxByDragRect(RECT* pRect, BOOL bAdd)
 
 	D3DVIEWPORT9 vp = pEng->s_CameraData.vp;
 
-	int i;
 	if (m_pSelRiver)	// 이미 선택된 강이 있다면..
 	{
 		int iVC = m_pSelRiver->VertexCount();	// 그강의 점 숫자를 구하기
-		for (i=0; i<iVC;++i)
+		for (int i=0; i<iVC;++i)
 		{
 			__VertexXyzT2* pVtx = m_pSelRiver->GetVertex(i);	// 점 하나 구하기
 			if (pVtx == NULL) continue;
@@ -517,8 +516,8 @@ void CRiverMng::SelectVtxByDragRect(RECT* pRect, BOOL bAdd)
 			CRiverMesh* pRM = *it;
 			if (pRM == NULL) continue;
 
-			int j, iVC = pRM->VertexCount();				// 이강의 점 갯수
-			for (j=0; j<iVC; ++j)
+			int iVC = pRM->VertexCount();				// 이강의 점 갯수
+			for (int j=0; j<iVC; ++j)
 			{
 				__VertexXyzT2* pVtx = pRM->GetVertex(j);	// 점 하나 구하기
 				if (pVtx == NULL) continue;
@@ -550,7 +549,7 @@ void CRiverMng::SelectVtxByDragRect(RECT* pRect, BOOL bAdd)
 	else
 	{
 		m_VtxPosDummy.SetSelVtx(m_SelVtxArray.GetAt(0));
-		for (i=1; i<iSize; ++i)
+		for (int i=1; i<iSize; ++i)
 		{
 			m_VtxPosDummy.AddSelVtx(m_SelVtxArray.GetAt(i));
 		}
@@ -682,7 +681,7 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 
 /*
 	// 모든 강 정보 저장 (*.grm) game river main
-	int i, j, k, iRiverCount = m_RiverMeshes.size();
+	int iRiverCount = m_RiverMeshes.size();
 
 	CLyTerrain* pTerrain = m_pMainFrm->GetMapMng()->GetTerrain();
 	SIZE size = pTerrain->GetPatchNum(fSize);
@@ -692,7 +691,7 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 	river.SetMaxPatchSize(size.cx, size.cy);
 
 	it_RiverMesh it = m_RiverMeshes.begin();
-	for(i = 0; i < iRiverCount; i++, it++)
+	for(int i = 0; i < iRiverCount; i++, it++)
 	{
 		CRiverMesh* pRM = *it;
 		ASSERT(pRM);
@@ -724,11 +723,11 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 	__TempPatch* TempPatches = new __TempPatch[iPatchCount];
 
 	it = m_RiverMeshes.begin();
-	for(i = 0; i < iRiverCount; i++, it++)
+	for(int i = 0; i < iRiverCount; i++, it++)
 	{
 		CRiverMesh* pRM = *it;
 		int iVC = pRM->VertexCount();
-		for (j=0; j<iVC; ++j)
+		for (int j=0; j<iVC; ++j)
 		{
 			__VertexXyzT2* pVtx = pRM->GetVertex(j);
 			int iX = int(pVtx->x/fSize);	int iZ = int(pVtx->z/fSize);
@@ -748,11 +747,11 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 
 	// CN3RiverPatch구조에 알맞게 넣기.
 	CN3RiverPatch* RiverPatches = new CN3RiverPatch[iPatchCount];
-	for (i=0; i<iPatchCount; ++i)
+	for (int i=0; i<iPatchCount; ++i)
 	{
 		int iRC = TempPatches[i].RiverArray.GetSize();
 		__River* Rivers = RiverPatches[i].CreateRiver(iRC);
-		for (j=0; j<iRC; ++j)
+		for (int j=0; j<iRC; ++j)
 		{
 			__TempRiver* pTempRiver = TempPatches[i].RiverArray.GetAt(j);	ASSERT(pTempRiver);
 			Rivers[j].iRiverID = pTempRiver->iRiverID;
@@ -762,7 +761,7 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 			if (iVC<=0) continue;
 			__VertexRiver* pVertices;
 			pVertices = Rivers[j].pVertices = new __VertexRiver[iVC];
-			for(k=0; k<iVC; ++k)
+			for(int k=0; k<iVC; ++k)
 			{
 				__TempVertex* pTempVtx = pTempRiver->VtxArray.GetAt(k);
 				pVertices[k].index = pTempVtx->index;
@@ -776,9 +775,9 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 	delete [] TempPatches;
 
 	// RiverPatches 저장하기
-	for (i=0; i<size.cx; ++i)
+	for (int i=0; i<size.cx; ++i)
 	{
-		for (j=0; j<size.cy; ++j)
+		for (int j=0; j<size.cy; ++j)
 		{
 			RiverPatches[j*size.cy + i].Save(hFile);
 		}
@@ -790,7 +789,7 @@ void CRiverMng::MakeGameFiles(HANDLE hFile, float fSize)
 void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 {
 	// 모든 강 정보 저장 (*.grm) game river main
-	int i, j, k, iRiverCount = m_RiverMeshes.size();
+	int iRiverCount = m_RiverMeshes.size();
 
 	CLyTerrain* pTerrain = m_pMainFrm->GetMapMng()->GetTerrain();
 	SIZE size = pTerrain->GetPatchNum(fSize);
@@ -799,7 +798,7 @@ void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 	__RiverInfo* RiverInfos = river.CreateRiverInfo(iRiverCount);
 	river.SetMaxPatchSize(size.cx, size.cy);
 
-	for (i=0; i<iRiverCount; ++i)
+	for (int i=0; i<iRiverCount; ++i)
 	{
 		CRiverMesh* pRM = m_RiverMeshes.Get(i);
 		ASSERT(pRM);
@@ -814,7 +813,7 @@ void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 		RiverInfos[i].fAnimTexFPS = pRM->GetAnimTexFPS();
 		int iAnimTexCount = pRM->GetAnimTexCount();
 		RiverInfos[i].SetAnimTexCount(iAnimTexCount);
-		for (j=0; j<iAnimTexCount; ++j)
+		for (int j=0; j<iAnimTexCount; ++j)
 		{
 			__ASSERT(pRM->AnimTexGet(j), "");
 			RiverInfos[i].SetAnimTexName(j, pRM->AnimTexGet(j)->Name());
@@ -831,11 +830,11 @@ void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 	// 각 패치별로 정보 분류하기
 	__TempPatch* TempPatches = new __TempPatch[iPatchCount];
 
-	for (i=0; i<iRiverCount; ++i)
+	for (int i=0; i<iRiverCount; ++i)
 	{
 		CRiverMesh* pRM = m_RiverMeshes.Get(i);
 		int iVC = pRM->VertexCount();
-		for (j=0; j<iVC; ++j)
+		for (int j=0; j<iVC; ++j)
 		{
 			__VertexXyzT2* pVtx = pRM->GetVertex(j);
 			int iX = int(pVtx->x/fSize);	int iZ = int(pVtx->z/fSize);
@@ -855,11 +854,11 @@ void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 
 	// CN3RiverPatch구조에 알맞게 넣기.
 	CN3RiverPatch* RiverPatches = new CN3RiverPatch[iPatchCount];
-	for (i=0; i<iPatchCount; ++i)
+	for (int i=0; i<iPatchCount; ++i)
 	{
 		int iRC = TempPatches[i].RiverArray.GetSize();
 		__River* Rivers = RiverPatches[i].CreateRiver(iRC);
-		for (j=0; j<iRC; ++j)
+		for (int j=0; j<iRC; ++j)
 		{
 			__TempRiver* pTempRiver = TempPatches[i].RiverArray.GetAt(j);	ASSERT(pTempRiver);
 			Rivers[j].iRiverID = pTempRiver->iRiverID;
@@ -869,7 +868,7 @@ void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 			if (iVC<=0) continue;
 			__VertexRiver* pVertices;
 			pVertices = Rivers[j].pVertices = new __VertexRiver[iVC];
-			for(k=0; k<iVC; ++k)
+			for(int k=0; k<iVC; ++k)
 			{
 				__TempVertex* pTempVtx = pTempRiver->VtxArray.GetAt(k);
 				pVertices[k].index = pTempVtx->index;
@@ -883,9 +882,9 @@ void CRiverMng::MakeGameFiles(LPCTSTR lpszFName, float fSize)
 	delete [] TempPatches;
 
 	// RiverPatches 저장하기
-	for (i=0; i<size.cx; ++i)
+	for (int i=0; i<size.cx; ++i)
 	{
-		for (j=0; j<size.cy; ++j)
+		for (int j=0; j<size.cy; ++j)
 		{
 			wsprintf(szTmpFName, "River\\%s_%02d%02d.grp", lpszFName, i, j);
 			RiverPatches[j*size.cy + i].SaveToFile(szTmpFName);

--- a/src/tool/N3ME/SowSeedMng.cpp
+++ b/src/tool/N3ME/SowSeedMng.cpp
@@ -56,7 +56,7 @@ void CSowSeedMng::Release()
 
 	if( Grass != NULL)
 	{
-		for( i = 0; i <Grass_Count ; i ++)
+		for(int i = 0; i < Grass_Count ; i++)
 		{
 				if(Grass[i].Sub_Grass != NULL)
 					delete Grass[i].Sub_Grass;
@@ -219,7 +219,6 @@ void CSowSeedMng::Render(LPDIRECT3DDEVICE9 lpD3DDevice)
 	{
 		return;
 	}
-	int i,j,Num=0;
 	CMainFrame* pFrame = (CMainFrame*)AfxGetMainWnd();
 
 
@@ -229,9 +228,9 @@ void CSowSeedMng::Render(LPDIRECT3DDEVICE9 lpD3DDevice)
 		if( Render_Grass == TRUE)
 		{
 			pFrame->GetMapMng()->GetTerrain()->RenderBrushArea();
-			for (i = 0,Num = 0 ; i < MAX_BRUSH_SIZE ; ++i)
+			for (int i = 0, Num = 0 ; i < MAX_BRUSH_SIZE ; ++i)
 			{
-				for (j = 0 ; j < MAX_BRUSH_SIZE ; ++j)
+				for (int j = 0 ; j < MAX_BRUSH_SIZE; ++j)
 				{
 					if(pFrame->GetMapMng()->GetTerrain()->m_fBrushIntensityMap[i][j] <= 0) 
 						continue;
@@ -293,14 +292,14 @@ void CSowSeedMng::Render(LPDIRECT3DDEVICE9 lpD3DDevice)
 	if( Render_Grass == TRUE)
 	{
 		it_Grass_Group it = Grass_Group.begin();
-		for( i = 0 ; i < Grass_Group.size(); i++,it++)
+		for(int i = 0 ; i < Grass_Group.size(); i++,it++)
 		{
 			LPGRASS_GROUP group = *it;
 			it_Grass it_grass = group->grass.begin();
 
 			if( Select_Group_Id != i)
 			{
-				for( j = 0 ; j < group->grass.size(); j++, it_grass++)
+				for(int j = 0; j < group->grass.size(); j++, it_grass++)
 				{
 					LPGRASS grass = *it_grass;
 
@@ -320,7 +319,7 @@ void CSowSeedMng::Render(LPDIRECT3DDEVICE9 lpD3DDevice)
 			if( Select_Group_Id == i )  // 선택된 그룹 
 			{
 				Render_Box(lpD3DDevice,group->Pos);
-				for( j = 0 ; j < group->grass.size(); j++, it_grass++)
+				for(int j = 0 ; j < group->grass.size(); j++, it_grass++)
 				{
 					LPGRASS grass = *it_grass;
 
@@ -475,7 +474,7 @@ void CSowSeedMng::Add_Grass(void)
 		
 
 		int Count = 0;
-		for( i = 0 ; i < MAX_BRUSH_SIZE ; i++)
+		for(int i = 0 ; i < MAX_BRUSH_SIZE; i++)
 		{
 			for( int j = 0 ; j < MAX_BRUSH_SIZE ;j++)
 			{
@@ -866,7 +865,7 @@ void CSowSeedMng::Test_GameDataSave(void)
 	}
 	int size = pFrm->GetMapMng()->m_SowSeedMng.Grass_Group.size();
 	it_Grass_Group it = pFrm->GetMapMng()->m_SowSeedMng.Grass_Group.begin();
-	for( i = 0 ; i < size ; i++,it++)
+	for(int i = 0 ; i < size ; i++,it++)
 	{
 		LPGRASS_GROUP group = (LPGRASS_GROUP)*it;
 		it_Grass it_grass = group->grass.begin();
@@ -907,7 +906,7 @@ void CSowSeedMng::Test_GameDataSave(void)
 		}
 	}
 
-	for( i = 0 ; i < Map_Size*Map_Size; i++)
+	for(int i = 0 ; i < Map_Size*Map_Size; i++)
 	{
 		WriteFile(hFile,&SeedAttr[i],sizeof(unsigned char),&dwRWC,NULL);
 		if( SeedAttr[i].sub_flage == 1)
@@ -946,7 +945,7 @@ void CSowSeedMng::Test_GameDataLoad(void)
 		SeedAttr[i].sub_flage = 0;
 	}
 
-	for( i = 0 ; i < Map_Size*Map_Size; i++)
+	for(int i = 0 ; i < Map_Size*Map_Size; i++)
 	{
 //		ReadFile(hFile,&SeedAttr[i],sizeof(unsigned char),&dwRWC,NULL);
 		fread(&SeedAttr[i],sizeof(unsigned char),1,fp);

--- a/src/tool/N3ME/TransDummy.cpp
+++ b/src/tool/N3ME/TransDummy.cpp
@@ -80,8 +80,7 @@ void CTransDummy::InitDummyCube(int iType, __DUMMYCUBE* pDummyCube, __Vector3& v
 	pDummyCube->Vertices[30].Set(vCubeV[6], vCubeN[5], color);	pDummyCube->Vertices[31].Set(vCubeV[2], vCubeN[5], color);	pDummyCube->Vertices[32].Set(vCubeV[1], vCubeN[5], color);
 	pDummyCube->Vertices[33].Set(vCubeV[6], vCubeN[5], color);	pDummyCube->Vertices[34].Set(vCubeV[1], vCubeN[5], color);	pDummyCube->Vertices[35].Set(vCubeV[5], vCubeN[5], color);
 
-	int i;
-	for (i=0; i<NUM_CUBEVERTEX; ++i)
+	for (int i=0; i<NUM_CUBEVERTEX; ++i)
 	{
 		pDummyCube->Vertices[i].x += vOffset.x;
 		pDummyCube->Vertices[i].y += vOffset.y;
@@ -103,13 +102,12 @@ void CTransDummy::Tick()
 	ReCalcMatrix();
 
 	// 거리에 따라 정렬
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		__Vector3 vPos = m_DummyCubes[i].vCenterPos*m_Matrix;
 		m_DummyCubes[i].fDistance = (vPos - s_CameraData.vEye).Magnitude();
 	}
-	for (i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
+	for (int i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
 	qsort(m_pSortedCubes, sizeof(__DUMMYCUBE*), NUM_DUMMY, SortCube);
 }
 
@@ -152,8 +150,7 @@ void CTransDummy::Render()
 
 	// Cube 그리기
 	hr = s_lpD3DDev->SetFVF(FVF_XYZNORMALCOLOR);
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		ASSERT(m_pSortedCubes[i]);
 		hr = s_lpD3DDev->DrawPrimitiveUP(D3DPT_TRIANGLELIST, 12, m_pSortedCubes[i]->Vertices, sizeof(__VertexXyzNormalColor));
@@ -186,10 +183,9 @@ __DUMMYCUBE* CTransDummy::Pick(int x, int y)
 	CPick pick;
 	pick.SetPickXY(x, y);
 
-	int i, j;
-	for (i=NUM_DUMMY-1; i>=0; --i)
+	for (int i=NUM_DUMMY-1; i>=0; --i)
 	{
-		for (j=0; j<12; ++j)
+		for (int j=0; j<12; ++j)
 		{
 			__Vector3 v1, v2, v3;
 			__VertexXyzNormalColor* pVertex;
@@ -310,11 +306,11 @@ void CTransDummy::GetPickRay(POINT point, __Vector3& vDir, __Vector3& vOrig)
 
 void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vector3* pvDiffScale)
 {
-	int i, iSize = m_SelObjArray.GetSize();
+	int iSize = m_SelObjArray.GetSize();
 	if (iSize<=0) return;
 	if (pvDiffPos)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			CN3Transform* pSelObj = m_SelObjArray.GetAt(i);
 			_ASSERT(pSelObj);
@@ -330,7 +326,7 @@ void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vec
 
 		D3DXMatrixRotationQuaternion(&mtx44Rotate,pqDiffRot);
 
-		for(i=0; i<iSize; ++i)
+		for(int i=0; i<iSize; ++i)
 		{
 			pSelObj = m_SelObjArray.GetAt(i);
 			_ASSERT(pSelObj);
@@ -348,7 +344,7 @@ void CTransDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vec
 	}
 	if (pvDiffScale)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			CN3Transform* pSelObj = m_SelObjArray.GetAt(i);
 			_ASSERT(pSelObj && m_vPrevScaleArray);

--- a/src/tool/N3ME/VtxPosDummy.cpp
+++ b/src/tool/N3ME/VtxPosDummy.cpp
@@ -44,13 +44,12 @@ void CVtxPosDummy::Tick()
 	ReCalcMatrix();
 
 	// 거리에 따라 정렬
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		__Vector3 vPos = m_DummyCubes[i].vCenterPos*m_Matrix;
 		m_DummyCubes[i].fDistance = (vPos - s_CameraData.vEye).Magnitude();
 	}
-	for (i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
+	for (int i=0; i<NUM_DUMMY; ++i) m_pSortedCubes[i] = &(m_DummyCubes[i]);
 	qsort(m_pSortedCubes, sizeof(__DUMMYCUBE*), NUM_DUMMY, SortCube);
 }
 
@@ -83,8 +82,7 @@ void CVtxPosDummy::Render()
 
 	// Cube 그리기
 	hr = s_lpD3DDev->SetFVF(FVF_XYZNORMALCOLOR);
-	int i;
-	for (i=0; i<NUM_DUMMY; ++i)
+	for (int i=0; i<NUM_DUMMY; ++i)
 	{
 		ASSERT(m_pSortedCubes[i]);
 		if (m_pSortedCubes[i]->iType == DUMMY_CENTER) continue;	// 가운데 큐브는 그리지 않는다.
@@ -246,11 +244,11 @@ BOOL CVtxPosDummy::MouseMsgFilter(LPMSG pMsg)				// 마우스 메세지 처리
 
 void CVtxPosDummy::TransDiff(__Vector3* pvDiffPos, __Quaternion* pqDiffRot, __Vector3* pvDiffScale)		// 차이만큼 선택된 오브젝트들을 변형시킨다.
 {
-	int i, iSize = m_SelVtxArray.GetSize();
+	int iSize = m_SelVtxArray.GetSize();
 	if (iSize<=0) return;
 	if (pvDiffPos)
 	{
-		for (i=0; i<iSize; ++i)
+		for (int i=0; i<iSize; ++i)
 		{
 			__VertexXyzT1* pSelVtx = m_SelVtxArray.GetAt(i);
 			_ASSERT(pSelVtx);

--- a/src/tool/N3TexViewer/MainFrm.cpp
+++ b/src/tool/N3TexViewer/MainFrm.cpp
@@ -452,13 +452,12 @@ BOOL CMainFrame::BMPCutter(LPCTSTR lpszFileName, int iWidth, int iHeight, bool b
 	// 새로 쪼개서 저장하기
 	BYTE *pTmpBitDest;
 	pTmpBitDest = ((BYTE*)pDestDIB) + sizeof(BITMAPINFOHEADER);
-	int i, j, y;
-	for (j=0; j<iCY; ++j)
+	for (int j=0; j<iCY; ++j)
 	{
-		for (i=0; i<iCX; ++i)
+		for (int i=0; i<iCX; ++i)
 		{
 			memset(pTmpBitDest, 0, iDestDIBSize - sizeof(BITMAPINFOHEADER));
-			for(y=0; y<iHeight; ++y)
+			for(int y=0; y<iHeight; ++y)
 			{
 				if ( (iHeight*j + y) >= bmInfoHeader.biHeight) break;	// 맨 아래가 짤릴 경우가 있다
 

--- a/src/tool/N3TexViewer/N3TexViewer.vcxproj
+++ b/src/tool/N3TexViewer/N3TexViewer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/N3TexViewer/N3TexViewerDoc.cpp
+++ b/src/tool/N3TexViewer/N3TexViewerDoc.cpp
@@ -203,11 +203,10 @@ void CN3TexViewerDoc::FindFiles()
 
 	CFileFind find;
 
-	int i = 0;
 	m_nCurFile = 0;
 	if(FALSE == find.FindFile("*.DXT")) return;
 
-	for(i = 0; find.FindNextFile(); i++)
+	for(int i = 0; find.FindNextFile(); i++)
 	{
 		CString szPathTmp = find.GetFilePath();
 		m_szFiles.Add(szPathTmp);

--- a/src/tool/N3Viewer/DlgPMeshEdit.cpp
+++ b/src/tool/N3Viewer/DlgPMeshEdit.cpp
@@ -391,7 +391,7 @@ void CDlgPMeshEdit::LOD_Delete()
 	CN3PMesh::__LODCtrlValue LODs[32]; // LOD Control Value 복사..
 	int nLOD = 0;
 	for(int i = 0; i < nSel; i++) LODs[nLOD++] = *(pPMesh->LODCtrlGet(i));
-	for(i = nSel + 1; i < nLODCount; i++) LODs[nLOD++] = *(pPMesh->LODCtrlGet(i));
+	for(int i = nSel + 1; i < nLODCount; i++) LODs[nLOD++] = *(pPMesh->LODCtrlGet(i));
 	pPMesh->LODCtrlSet(LODs, nLOD);
 	pPMesh->SaveToFile(); // 저장..
 

--- a/src/tool/N3Viewer/N3Viewer.vcxproj
+++ b/src/tool/N3Viewer/N3Viewer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/N3Viewer/N3ViewerView.cpp
+++ b/src/tool/N3Viewer/N3ViewerView.cpp
@@ -308,7 +308,7 @@ CN3Base* CN3ViewerView::Pick(POINT point, int* pnPart)
 
 	CN3Chr* pChr;
 	int nCC = pScene->ChrCount();
-	for(i = 0; i < nCC; i++)
+	for(int i = 0; i < nCC; i++)
 	{
 		pChr = pScene->ChrGet(i);
 		_ASSERT(pChr);
@@ -324,7 +324,7 @@ CN3Base* CN3ViewerView::Pick(POINT point, int* pnPart)
 
 	int nPart = -1;
 	__Vector3 vI;
-	for(i = 0; i < nSortCount; i++)
+	for(int i = 0; i < nSortCount; i++)
 	{
 		nPart = sort[i].pObj->CheckCollisionPrecisely(true, point.x, point.y);
 		if(nPart >= 0)

--- a/src/tool/N3Viewer/ViewProperty.cpp
+++ b/src/tool/N3Viewer/ViewProperty.cpp
@@ -438,7 +438,7 @@ void CViewProperty::UpdateInfo()
 		int nPlug = m_CBChrPlug.GetCurSel();
 		int nPlugCount = pC->PlugCount();
 		m_CBChrPlug.ResetContent();
-		for(i = 0; i < nPlugCount; i++)
+		for(int i = 0; i < nPlugCount; i++)
 		{
 			CString szTmp;
 			szTmp.Format("Plug : %d", i);
@@ -925,7 +925,6 @@ void CViewProperty::OnInitialUpdate()
 		/////////////////////////////////////
 
 
-		int i = 0;
 		CString str, strTmp;
 
 		/////////////////////////////////////
@@ -958,7 +957,7 @@ void CViewProperty::OnInitialUpdate()
 		// Shape
 		m_CBShapePart.ResetContent();
 	//	int nPartCount = 
-	//	for(i = 0; i < nPartCount; i++) { strTmp.Format("%d", i); m_CBShapePart.AddString(strTmp); }
+	//	for(int i = 0; i < nPartCount; i++) { strTmp.Format("%d", i); m_CBShapePart.AddString(strTmp); }
 	//	m_CBShapePart.SetCurSel(0);
 
 		m_LPShape.AddPropItem("¼Ò¼Ó", "", PIT_EDIT, "");
@@ -999,7 +998,7 @@ void CViewProperty::OnInitialUpdate()
 		m_CBChrPart.SetCurSel(0);
 
 		m_CBChrLOD.ResetContent();
-		for(i = 0; i < MAX_CHR_LOD; i++) { strTmp.Format("LOD : %d", i); m_CBChrLOD.AddString(strTmp); }
+		for(int i = 0; i < MAX_CHR_LOD; i++) { strTmp.Format("LOD : %d", i); m_CBChrLOD.AddString(strTmp); }
 		m_CBChrLOD.SetCurSel(0);
 
 		m_LPCPart.AddPropItem("Part File", "", PIT_FILE, "N3 Character part file(*.N3CPart)|*.N3CPart||");

--- a/src/tool/N3Viewer/ViewSceneTree.cpp
+++ b/src/tool/N3Viewer/ViewSceneTree.cpp
@@ -170,46 +170,45 @@ void CViewSceneTree::UpdateTreeItem(HTREEITEM hParent, CN3Base *pBase)
 		str.Format("Scene : %s", pScene->m_szName.c_str());
 		GetTreeCtrl().SetItemText(hItem, str);
 
-		int i = 0;
 		HTREEITEM hItem2 = NULL;
 
 		hItem2 = GetTreeCtrl().InsertItem("Camera", 3, 3, hItem);
 		int nCC = pScene->CameraCount();
-		for(i = 0; i < nCC; i++) this->UpdateTreeItem(hItem2, pScene->CameraGet(i));
+		for(int i = 0; i < nCC; i++) this->UpdateTreeItem(hItem2, pScene->CameraGet(i));
 
 		hItem2 = GetTreeCtrl().InsertItem("Light", 4, 4, hItem);
 		int nLC = pScene->LightCount();
-		for(i = 0; i < nLC; i++) this->UpdateTreeItem(hItem2, pScene->LightGet(i));
+		for(int i = 0; i < nLC; i++) this->UpdateTreeItem(hItem2, pScene->LightGet(i));
 		
 		hItem2 = GetTreeCtrl().InsertItem("Shape", 6, 6, hItem);
 		int nSC = pScene->ShapeCount();
-		for(i = 0; i < nSC; i++) this->UpdateTreeItem(hItem2, pScene->ShapeGet(i));
+		for(int i = 0; i < nSC; i++) this->UpdateTreeItem(hItem2, pScene->ShapeGet(i));
 		GetTreeCtrl().SortChildren(hItem2);
 
 		hItem2 = GetTreeCtrl().InsertItem("Character", 8, 8, hItem);
 		int nCC2 = pScene->ChrCount();
-		for(i = 0; i < nCC2; i++) this->UpdateTreeItem(hItem2, pScene->ChrGet(i));
+		for(int i = 0; i < nCC2; i++) this->UpdateTreeItem(hItem2, pScene->ChrGet(i));
 		GetTreeCtrl().SortChildren(hItem2);
 
 /*		hItem2 = GetTreeCtrl().InsertItem("Mesh Resource", hItem);
 		int nMC = pScene->m_MngMesh.Count();
-		for(i = 0; i < nMC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngMesh.Get(i));
+		for(int i = 0; i < nMC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngMesh.Get(i));
 
 		hItem2 = GetTreeCtrl().InsertItem("Progressive Mesh Resource", hItem);
 		int nPMC = pScene->m_MngPMesh.Count();
-		for(i = 0; i < nPMC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngPMesh.Get(i));
+		for(int i = 0; i < nPMC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngPMesh.Get(i));
 
 		hItem2 = GetTreeCtrl().InsertItem("Indexed Mesh Resource", hItem);
 		int nIMC = pScene->m_MngIMesh.Count();
-		for(i = 0; i < nIMC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngIMesh.Get(i));
+		for(int i = 0; i < nIMC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngIMesh.Get(i));
 
 		hItem2 = GetTreeCtrl().InsertItem("Joint Resource", hItem);
 		int nJC = pScene->m_MngJoint.Count();
-		for(i = 0; i < nJC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngJoint.Get(i));
+		for(int i = 0; i < nJC; i++) this->UpdateTreeItem(hItem2, pScene->m_MngJoint.Get(i));
 
 		hItem2 = GetTreeCtrl().InsertItem("Skin Resource", hItem);
 		int nSC2 = pScene->m_MngSkin.Count();
-		for(i = 0; i < nSC2; i++) this->UpdateTreeItem(hItem2, pScene->m_MngSkin.Get(i));
+		for(int i = 0; i < nSC2; i++) this->UpdateTreeItem(hItem2, pScene->m_MngSkin.Get(i));
 */
 	}
 /*	else if(pBase->Type() & OBJ_CHARACTER)

--- a/src/tool/Option/Option.vcxproj
+++ b/src/tool/Option/Option.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -94,7 +93,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/PlugIn_Max/N3DExp.cpp
+++ b/src/tool/PlugIn_Max/N3DExp.cpp
@@ -774,7 +774,6 @@ bool CN3DExp::ProcessName(INode* pNode, CN3BaseFileAccess* pBase)
 
 bool CN3DExp::ProcessChr(INode *pNode)
 {
-	int i, nCC;
 	INode* pNodeRootJoint = NULL; // 루트 조인트를 찾아야 한다..
 
 	Control* pCtrl = pNode->GetTMController();
@@ -785,7 +784,7 @@ bool CN3DExp::ProcessChr(INode *pNode)
 	else
 	{	// pNode가 바이패드면 자식중에 루트조인트를 찾는다.
 
-		nCC = pNode->NumberOfChildren();
+		int nCC = pNode->NumberOfChildren();
 		for(int i = 0; i < nCC; i++) 
 		{
 			INode* pNodeTmp = pNode->GetChildNode(i);
@@ -828,7 +827,7 @@ bool CN3DExp::ProcessChr(INode *pNode)
 	pChr->m_szName = "Temp";
 	pChr->FileNameSet(std::string("Chr\\Temp.n3Chr"));
 	pChr->PartAlloc(64); // 충분하게 Part Data 할당.. save할때 불필요한 데이터는 제거된다.
-	for(i = 0; i < 64; i++)
+	for(int i = 0; i < 64; i++)
 	{
 		CN3CPart* pPDAdd = pChr->Part(i);
 		CN3CPartSkins* pSkinAdd = new CN3CPartSkins();
@@ -872,8 +871,8 @@ bool CN3DExp::ProcessChr(INode *pNode)
 			{
 				std::string strM1(pNodeTmp->GetName());
 				std::string strM2;
-				nCC = pMG->NumberOfChildren();
-				for(i = 0; i < nCC; i++)
+				int nCC = pMG->NumberOfChildren();
+				for(int i = 0; i < nCC; i++)
 				{
 					INode* pCN = pMG->GetChildNode(i);
 					__ASSERT(pCN, "null pointer : no child");
@@ -888,8 +887,8 @@ bool CN3DExp::ProcessChr(INode *pNode)
 				// part
 				std::string strM1(pMG->GetName());
 				std::string strM2;
-				nCC = pCG->NumberOfChildren();
-				for(i = 0; i < nCC; i++)
+				int nCC = pCG->NumberOfChildren();
+				for(int i = 0; i < nCC; i++)
 				{
 					INode* pCN = pCG->GetChildNode(i);
 					__ASSERT(pCN, "null pointer : no child");
@@ -901,8 +900,8 @@ bool CN3DExp::ProcessChr(INode *pNode)
 
 				// lod
 				strM1 = pNodeTmp->GetName();
-				nCC = pMG->NumberOfChildren();
-				for(i = 0; i < nCC; i++)
+				int nCC = pMG->NumberOfChildren();
+				for(int i = 0; i < nCC; i++)
 				{
 					INode* pCN = pMG->GetChildNode(i);
 					__ASSERT(pCN, "null pointer : no child");
@@ -1119,7 +1118,7 @@ bool CN3DExp::ProcessTransform(INode* pNode, CN3Transform* pTransform, bool bLoc
 
 	// 키값 정리..
 	CN3AnimKey* pKey[3] = { &(pTransform->m_KeyPos), &(pTransform->m_KeyRot), &(pTransform->m_KeyScale) };
-	for(i = 0; i < 3; i++)
+	for(int i = 0; i < 3; i++)
 	{
 		nKC = pKey[i]->Count();
 		
@@ -1401,7 +1400,7 @@ bool CN3DExp::ProcessIMesh(INode *pNode, CN3IMesh* pIMesh)
 			pvDest1[i].y = ptTmp.z; // * 0.0254f;
 			pvDest1[i].z = ptTmp.y; // * 0.0254f; // y 와 z 를 바꾼다..
 		}
-		for(i = 0; i < nUVC; i++)
+		for(int i = 0; i < nUVC; i++)
 		{
 			pIMesh->UVSet(i, pmMesh->tVerts[i].x, 1.0f - pmMesh->tVerts[i].y); // 일단 텍스처 매핑을 기록해 둔다..
 		}

--- a/src/tool/PlugIn_Maya/N3E2Wrapper.cpp
+++ b/src/tool/PlugIn_Maya/N3E2Wrapper.cpp
@@ -263,17 +263,15 @@ void CN3E2Wrapper::SceneExport()
 
 	MObjectArray mObjects;
 
-	int i = 0;
-
 	MItDependencyNodes IterNodes1(MFn::kCamera); // scene 의 노드들을 체크..
 	MItDependencyNodes IterNodes2(MFn::kLight); // scene 의 노드들을 체크..
 	MItDependencyNodes IterNodes3(MFn::kMesh); // scene 의 노드들을 체크..
 	MItDependencyNodes IterNodes4(MFn::kSkinClusterFilter); // scene 의 노드들을 체크..
 
-	for(i = 0; !IterNodes1.isDone(); IterNodes1.next(), i++) mObjects.append(IterNodes1.item());
-	for(i = 0; !IterNodes2.isDone(); IterNodes2.next(), i++) mObjects.append(IterNodes2.item());
-	for(i = 0; !IterNodes3.isDone(); IterNodes3.next(), i++) mObjects.append(IterNodes3.item());
-	for(i = 0; !IterNodes4.isDone(); IterNodes4.next(), i++) mObjects.append(IterNodes4.item());
+	for(int i = 0; !IterNodes1.isDone(); IterNodes1.next(), i++) mObjects.append(IterNodes1.item());
+	for(int i = 0; !IterNodes2.isDone(); IterNodes2.next(), i++) mObjects.append(IterNodes2.item());
+	for(int i = 0; !IterNodes3.isDone(); IterNodes3.next(), i++) mObjects.append(IterNodes3.item());
+	for(int i = 0; !IterNodes4.isDone(); IterNodes4.next(), i++) mObjects.append(IterNodes4.item());
 
 	MSelectionList mSelList;
 	if(m_Option.bExportSelectedOnly)
@@ -292,7 +290,7 @@ void CN3E2Wrapper::SceneExport()
 
 	m_bCancelExport = FALSE;
 
-	for (i = 0; i < nObjectCount && FALSE == m_bCancelExport; i++)
+	for (int i = 0; i < nObjectCount && FALSE == m_bCancelExport; i++)
 	{
 		// Dialog Message 처리...
 		MSG msg;
@@ -503,7 +501,7 @@ bool CN3E2Wrapper::ProcessIMesh(MFnMesh &mMesh, CN3IMesh* pIMesh)
 	mMtxWorldRot.matrix[3][3] = 1.0;
 	
 	__VertexXyzNormal* pVDest = pIMesh->Vertices();
-	for(i = 0; i < nVC; i++) 
+	for(int i = 0; i < nVC; i++) 
 	{
 		MPoint mVTmp = mVArray[i]; // World Matrix 곱하고..
 		mVTmp *= mMtxWorld;
@@ -527,9 +525,9 @@ bool CN3E2Wrapper::ProcessIMesh(MFnMesh &mMesh, CN3IMesh* pIMesh)
 
 	}
 
-	for(i = 0; i < nUVC; i++) pIMesh->UVSet(i, mFAU[i], 1.0f - mFAV[i]); // UV 데이터 세팅..
-//	for(i = 0; i < nUVC; i++) pIMesh->UVSet(i, mFAU[i], mFAV[i]); // UV 데이터 세팅..
-	for(i = 0; i < nFC; i++) // 
+	for(int i = 0; i < nUVC; i++) pIMesh->UVSet(i, mFAU[i], 1.0f - mFAV[i]); // UV 데이터 세팅..
+//	for(int i = 0; i < nUVC; i++) pIMesh->UVSet(i, mFAU[i], mFAV[i]); // UV 데이터 세팅..
+	for(int i = 0; i < nFC; i++) // 
 	{
 		pIMesh->VertexIndexSet(i*3+0, mVIArray[i*3+0]); // Vertex Index 세팅
 		pIMesh->VertexIndexSet(i*3+1, mVIArray[i*3+2]);
@@ -732,7 +730,7 @@ bool CN3E2Wrapper::ProcessSkin(MFnSkinCluster &mSkin, CN3Skin* pSkin)
 			pVBone[i].pnJoints = new int[nAffect];
 			if(nAffect > 1) pVBone[i].pfWeights = new float[nAffect];
 
-			for (j = 0; j < nAffect; j++ )
+			for (int j = 0; j < nAffect; j++ )
 			{
 				pVBone[i].pnJoints[j] = s_nJoints[j];
 				if(nAffect > 1) pVBone[i].pfWeights[j] = s_fWeights[j];
@@ -828,7 +826,7 @@ bool CN3E2Wrapper::ProcessShape(MFnMesh& mMesh)
 
 		__VertexT1* pVSrc = IMesh.BuildVertexList();
 		__Vector3* pVDest = pVMesh->Vertices();
-		for(i = 0; i < nFC * 3; i++)
+		for(int i = 0; i < nFC * 3; i++)
 		{
 			pVDest[i].x = pVSrc[i].x; // 위치만 세팅해 준다...
 			pVDest[i].y = pVSrc[i].y; // 위치만 세팅해 준다...
@@ -1201,7 +1199,7 @@ CN3Texture* CN3E2Wrapper::ProcessTexture(MFnMesh &mMesh)
 	char szFNDest[1024]; // 저장할 이름
 	lstrcpy(szFNDest, szFNSrc);
 	nFN = lstrlen(szFNDest);
-	for(i = nFN - 1; i >= 0; i--) // 저장할 이름을 만든다..
+	for(int i = nFN - 1; i >= 0; i--) // 저장할 이름을 만든다..
 	{
 		if(szFNDest[i] == '.') { szFNDest[i+1] = 'D'; szFNDest[i+2] = 'X'; szFNDest[i+3] = 'T'; szFNDest[i+4] = NULL; }
 		if(szFNDest[i] == '\\' || szFNDest[i] == '/') 
@@ -1215,7 +1213,7 @@ CN3Texture* CN3E2Wrapper::ProcessTexture(MFnMesh &mMesh)
 
 	static char szFNs[1024][256]; // 파일 이름이 중복되는지 체크...
 	if(m_pScene->s_MngTex.Count() <= 0) memset(szFNs, 0, sizeof(szFNs));
-	for(i = 0; i < 1024; i++)
+	for(int i = 0; i < 1024; i++)
 	{
 		if(NULL == szFNs[i][0]) break;
 		if(lstrcmpi(szFNDest, szFNs[i]) == 0)
@@ -1539,7 +1537,7 @@ int CN3E2Wrapper::ProcessTransform(MFnTransform &mTransform, CN3Transform *pTran
 		else continue;
 	}
 
-	for(i = 0; i < 3; i++)
+	for(int i = 0; i < 3; i++)
 	{
 		int nKs[3];
 		nKs[0] = mACs[i][0].numKeys();
@@ -1591,7 +1589,7 @@ int CN3E2Wrapper::ProcessTransform(MFnTransform &mTransform, CN3Transform *pTran
 				} // end of if(i == 0)
 			} // end of if(nKs[0] <= 0 || nKs[1] <= 0 || nKs[2] <= 0)
 		} // end of if(nKs[0] > 0 || nKs[1] > 0 || nKs[2] > 0)
-	} // end of for(i = 0; i < 3; i++)
+	} // end of for(int i = 0; i < 3; i++)
 
 	if(pTransform->Type() & OBJ_JOINT) // Joint 이면... Orient 키 값도 본다..
 	{
@@ -1647,7 +1645,7 @@ void CN3E2Wrapper::ProcessAnimKey(	MFnAnimCurve* pmACs,
 		else if(MTransformationMatrix::kZYX == mRotOrder) { nRotSeqs[0] = 2; nRotSeqs[1] = 1; nRotSeqs[2] = 0; }
 		else MessageBox(::GetActiveWindow(), "Not supported rotation order", "Warning - animation key", MB_OK);
 
-		for(i = 0; i < nFrmMax; i++)
+		for(int i = 0; i < nFrmMax; i++)
 		{
 			pQt = (__Quaternion*)(pKey->DataGet(i));
 
@@ -1701,7 +1699,7 @@ void CN3E2Wrapper::ProcessAnimKey(	MFnAnimCurve* pmACs,
 	{
 		double dfValue;
 		__Vector3* pV = NULL;
-		for(i = 0; i < nFrmMax; i++)
+		for(int i = 0; i < nFrmMax; i++)
 		{
 			pV = (__Vector3*)(pKey->DataGet(i));
 
@@ -1749,11 +1747,11 @@ bool CN3E2Wrapper::ProcessChr(MFnSkinCluster &mSkin)
 	static std::string szJointFNs[512]; // 중복되는지 체크...
 	if(m_pScene->s_MngJoint.Count() <= 0) 
 	{
-		for(i = 0; i < 512; i++) szJointFNs[i] = "";
+		for(int i = 0; i < 512; i++) szJointFNs[i] = "";
 	}
 
 	bool bOverlapped = false;
-	for(i = 0; i < 256; i++)
+	for(int i = 0; i < 256; i++)
 	{
 		if(szJointFNs[i].size() <= 0) break;
 		if(szJointFN == szJointFNs[i])
@@ -1845,7 +1843,7 @@ bool CN3E2Wrapper::ProcessChr(MFnSkinCluster &mSkin)
 
 			pJoint->PosSet(pJoint->Pos() * mtxRotG); // 위치 값도 방향과 스케일에 맞게 
 			int nK = pJoint->m_KeyPos.Count(); // 에니메이션 키도 변경해준다..
-			for(i = 0; i < nK; i++)
+			for(int i = 0; i < nK; i++)
 			{
 				__Vector3* pvKey = (__Vector3*)(pJoint->m_KeyPos.DataGet(i));
 				(*pvKey) *= mtxRotG;
@@ -1935,7 +1933,7 @@ bool CN3E2Wrapper::ProcessChr(MFnSkinCluster &mSkin)
 		{
 			MFnTransform mCT(mGT.parent(0)); // Character Transform
 			int nC = mCT.childCount();
-			for(i = 0; i < nC; i++)
+			for(int i = 0; i < nC; i++)
 			{
 				if(!mCT.child(i).hasFn(MFn::kTransform)) continue;
 
@@ -1945,7 +1943,7 @@ bool CN3E2Wrapper::ProcessChr(MFnSkinCluster &mSkin)
 			}
 
 			int nGTC = mGT.childCount();
-			for(i = 0; i < nGTC; i++)
+			for(int i = 0; i < nGTC; i++)
 			{
 				if(!mGT.child(i).hasFn(MFn::kTransform)) continue; 
 
@@ -1957,7 +1955,7 @@ bool CN3E2Wrapper::ProcessChr(MFnSkinCluster &mSkin)
 		else // pair of if(mGT.parentCount() > 0 && mGT.parent(0).apiType() == MFn::kTransform) // 그룹 트랜스폼의 상위 노드가 있을 경우..
 		{
 			int nC = mGT.childCount();
-			for(i = 0; i < nC; i++)
+			for(int i = 0; i < nC; i++)
 			{
 				if(mGT.child(i).apiType() != MFn::kTransform) continue;
 

--- a/src/tool/RscTables/RscTables.vcxproj
+++ b/src/tool/RscTables/RscTables.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -94,7 +93,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/RscTables/RscTablesDlg.cpp
+++ b/src/tool/RscTables/RscTablesDlg.cpp
@@ -320,8 +320,8 @@ void CRscTablesDlg::OnClose()
 void CRscTablesDlg::UpdateInfo()
 {
 	// 화면에 표시
-	int i, iDataCount = m_Generator.DataTypeCount();
-	for (i=0; i<iDataCount; ++i)
+	int iDataCount = m_Generator.DataTypeCount();
+	for (int i=0; i<iDataCount; ++i)
 	{
 		int iSel = -1;
 
@@ -571,7 +571,7 @@ void CRscTablesDlg::OnItemFileListLoad()
 
 	m_Generator.OpenSource(szBuffs[0], szBuffs[1]);
 	m_Generator.OpenReference_Enum(szBuffs[2]);
-	for(i = 0; i < MAX_ITEM_EXTENSION + 3; i++)
+	for(int i = 0; i < MAX_ITEM_EXTENSION + 3; i++)
 	{
 		m_Generator.OpenReference_Txt(i, szBuffs[i+3]);
 	}
@@ -598,7 +598,7 @@ void CRscTablesDlg::OnItemFileListSave()
 
 	FILE* pFile = fopen(dlg.GetPathName(), "w");
 	if(NULL == pFile) return;
-	for(i = 0; i < MAX_ITEM_EXTENSION + 3; i++)
+	for(int i = 0; i < MAX_ITEM_EXTENSION + 3; i++)
 	{
 		fputs(szBuffs[i], pFile);
 		fputs("\n", pFile);

--- a/src/tool/RscTables/TableGenerator.cpp
+++ b/src/tool/RscTables/TableGenerator.cpp
@@ -64,7 +64,7 @@ bool CTableGenerator::OpenSource(const std::string &szEnumFileName, const std::s
 	typedef typename std::set<int>::iterator it_Key;
 	typedef std::pair<it_Key, bool> pair_Key;
 
-	for(i = 0; true; i++)
+	for(int i = 0; true; i++)
 	{
 		if(NULL == fgets(szLine, 1024, pFile)) break;
 		if(NULL == szLine[0] || '\r' == szLine[0] || '\n' == szLine[0]) continue;
@@ -310,7 +310,7 @@ bool CTableGenerator::Generate(int iIndex, const std::string& szEnumFileName, co
 	int iExt = iIndexS;
 	int iCountWhole2 = 0; // 실제 처리한 갯수..
 	int iAddTitle = -1;
-	for(i = 0; i < iCountWhole; i++)
+	for(int i = 0; i < iCountWhole; i++)
 	{
 		int iType = m_Datas[IG1_GEN_TYPE].m_dwValues[iIndexCur1]; // 아이템 생성타입..
 
@@ -480,7 +480,7 @@ bool CTableGenerator::Generate(int iIndex, const std::string& szEnumFileName, co
 				}
 			} // end of for(int j = 0; j < iDTCountBasic; j++)
 
-			for(j = 0; j < iDTCountRef; j++)
+			for(int j = 0; j < iDTCountRef; j++)
 			{
 				DATA_TYPE dt = m_DataExts[j].m_Type;
 
@@ -545,10 +545,10 @@ bool CTableGenerator::Generate(int iIndex, const std::string& szEnumFileName, co
 				iExt++;
 			}
 		}
-	} // end of for(i = 0; i < iCountWhole; i++)
+	} // end of for(int i = 0; i < iCountWhole; i++)
 	
 	int iColCount = pLineArrays[0].size();
-	for(i = 0; i <= iCountWhole; i++) // 설명까지 쓴다.
+	for(int i = 0; i <= iCountWhole; i++) // 설명까지 쓴다.
 	{
 		if(pLineArrays[i].empty()) continue;
 
@@ -793,7 +793,7 @@ bool CTableGenerator::Convert2Bin(const std::string& szFN)
 			return false;
 		}
 
-		//for (j=0; j<m_iDataCount; ++j)
+		//for (int j=0; j<m_iDataCount; ++j)
 		while(iColCount<iDataCount)
 		{
 			if (bQuotationActived)
@@ -976,7 +976,7 @@ bool CTableGenerator::Convert2Bin(const std::string& szFN)
 //}
 	
 	// 암호화 인코딩...
-	for(i = 0; i < dwSizeLow; i++)
+	for(int i = 0; i < dwSizeLow; i++)
 	{
 		BYTE byData = (pDatas[i] ^ (key_r>>8));
 		key_r = (byData + key_r) * key_c1 + key_c2;

--- a/src/tool/ServerInfoViewer/ServerInfoViewer.vcxproj
+++ b/src/tool/ServerInfoViewer/ServerInfoViewer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/SkyViewer/FormViewProperty.cpp
+++ b/src/tool/SkyViewer/FormViewProperty.cpp
@@ -273,17 +273,15 @@ void CFormViewProperty::UpdateAllInfo()
 	if(pDoc->m_Sky.MoonTextureGet()) SetDlgItemText(IDC_E_MOON_TEXTURE, pDoc->m_Sky.MoonTextureGet()->FileName().c_str());
 	else SetDlgItemText(IDC_E_MOON_TEXTURE, "");
 
-	int i = 0;
-
 	m_ListSunTextures.ResetContent();
-	for(i = 0; i < NUM_SUNPART; i++)
+	for(int i = 0; i < NUM_SUNPART; i++)
 	{
 		if(pDoc->m_Sky.SunTextureGet(i)) m_ListSunTextures.AddString(pDoc->m_Sky.SunTextureGet(i)->FileName().c_str());
 		else m_ListSunTextures.AddString("");
 	}
 	
 	m_ListCloudTextures.ResetContent();
-	for(i = 0; i < NUM_CLOUD; i++)
+	for(int i = 0; i < NUM_CLOUD; i++)
 	{
 		m_ListCloudTextures.AddString(pDoc->m_Sky.CloudTextureFileName(i));
 	}
@@ -293,7 +291,7 @@ void CFormViewProperty::UpdateAllInfo()
 
 	m_ListDayChanges.ResetContent();
 	int iSDCC = pDoc->m_Sky.DayChangeCount();
-	for(i = 0; i < iSDCC; i++)
+	for(int i = 0; i < iSDCC; i++)
 	{
 		__SKY_DAYCHANGE* pSDC = pDoc->m_Sky.DayChangeGet(i);
 		m_ListDayChanges.AddString(pSDC->szName.c_str());

--- a/src/tool/SkyViewer/SkyViewer.vcxproj
+++ b/src/tool/SkyViewer/SkyViewer.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/UIE/DlgTexture.cpp
+++ b/src/tool/UIE/DlgTexture.cpp
@@ -81,8 +81,7 @@ BOOL CDlgTexture::OnInitDialog()
 	if (m_iImageTypeCount>0)
 	{
 		m_ImageType.ShowWindow(SW_SHOW);
-		int i;
-		for (i=0; i<m_iImageTypeCount; ++i)	m_ImageType.AddString(m_szImageTypeNames[i]);
+		for (int i=0; i<m_iImageTypeCount; ++i)	m_ImageType.AddString(m_szImageTypeNames[i]);
 		m_ImageType.SetCurSel(0);
 		m_pTexViewer->SetImageTypeIndex(0);
 	}
@@ -121,8 +120,7 @@ void CDlgTexture::OnOK()
 	ASSERT(m_pTexViewer);
 	if (m_iImageTypeCount>0)
 	{	// 모두 영역 선택이 되었나 체크
-		int i;
-		for (i=0; i<m_iImageTypeCount; ++i)
+		for (int i=0; i<m_iImageTypeCount; ++i)
 		{
 			if (-1 == m_pTexViewer->GetImageRect(i).left)
 			{
@@ -301,8 +299,7 @@ void CDlgTexture::SetImageTypes(int iCount, char** pszNames)
 	m_pTexViewer->SetImageTypeCount(iCount);
 	m_iImageTypeCount = iCount;
 
-	int i;
-	for (i=0; i<iCount; ++i) lstrcpy(m_szImageTypeNames[i], pszNames[i]);
+	for (int i=0; i<iCount; ++i) lstrcpy(m_szImageTypeNames[i], pszNames[i]);
 }
 
 CRect CDlgTexture::GetImageRect(int iIndex, __FLOAT_RECT* pUVRect)

--- a/src/tool/UIE/PropertyView.cpp
+++ b/src/tool/UIE/PropertyView.cpp
@@ -322,8 +322,7 @@ BOOL CPropertyView::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 				dlgTex.SetTexture(szTexFName);
 				char szNames[1000][20];
 				char* szImageTypeNames[1000];
-				int i;
-				for (i=0; i<dlgAnim.m_iCount; ++i)
+				for (int i=0; i<dlgAnim.m_iCount; ++i)
 				{
 					wsprintf(szNames[i], "%d", i);
 					szImageTypeNames[i] = szNames[i];
@@ -331,7 +330,7 @@ BOOL CPropertyView::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 				dlgTex.SetImageTypes(dlgAnim.m_iCount, szImageTypeNames);
 				if (IDCANCEL == dlgTex.DoModal()) break;	// 취소의 경우
 				CN3UIImage* pChildImage;
-				for (i=0; i<dlgAnim.m_iCount; ++i)
+				for (int i=0; i<dlgAnim.m_iCount; ++i)
 				{
 					__FLOAT_RECT frcUV;
 					dlgTex.GetImageRect(i, &frcUV);

--- a/src/tool/UIE/TexViewer.cpp
+++ b/src/tool/UIE/TexViewer.cpp
@@ -119,10 +119,9 @@ void CTexViewer::OnPaint()
 		dc.SelectObject(pOldPen);
 	}
 	// ImageType별 영역이 있으면 그리기
-	int i;
 	int iOldMode = dc.SetROP2(R2_NOTXORPEN);
 	dc.SelectStockObject(NULL_BRUSH);
-	for (i=0; i<m_iImageTypeCount; ++i)
+	for (int i=0; i<m_iImageTypeCount; ++i)
 	{
 		if (m_iCurSelectedImage == i) continue;	// 현재 선택된 것은 건너뛰기
 		CRect rcTmp = m_ImageRects[i];
@@ -378,8 +377,7 @@ void CTexViewer::Release()
 	m_ptClickOffset = CPoint(-1,-1);
 
 	// image type관련
-	int i;
-	for (i=0; i<MAX_IMAGETYPE; ++i)
+	for (int i=0; i<MAX_IMAGETYPE; ++i)
 	{
 		m_ImageRects[i].SetRect(-1,-1,-1,-1);
 	}
@@ -701,13 +699,12 @@ BOOL CTexViewer::AutoMultiRectSelect(BOOL bHorizon, CString& strErrMsg)	// 가로 
 	}
 
 	Invalidate();
-	int i;
 	int iRow = 0;
 	int iCol = 0;
 	CPoint ptLeftTop = m_rcSelectedRect.TopLeft();
 	if (bHorizon)
 	{	// 수평으로 이동하며 나누기
-		for(i=0; i<m_iImageTypeCount; ++i)
+		for(int i=0; i<m_iImageTypeCount; ++i)
 		{
 			if ( (ptLeftTop.x + m_rcSelectedRect.Width()*(iRow+1)) > m_TexSize.cx) {++iCol; iRow = 0;}
 			if ( (ptLeftTop.y + m_rcSelectedRect.Height()*(iCol+1)) > m_TexSize.cy)
@@ -724,7 +721,7 @@ BOOL CTexViewer::AutoMultiRectSelect(BOOL bHorizon, CString& strErrMsg)	// 가로 
 	}
 	else
 	{	// 수직으로 이동하며 나누기
-		for(i=0; i<m_iImageTypeCount; ++i)
+		for(int i=0; i<m_iImageTypeCount; ++i)
 		{
 			if ( (ptLeftTop.y + m_rcSelectedRect.Height()*(iCol+1)) > m_TexSize.cy) {++iRow; iCol = 0;}
 			if ( (ptLeftTop.x + m_rcSelectedRect.Width()*(iRow+1)) > m_TexSize.cx)

--- a/src/tool/UIE/UIE.vcxproj
+++ b/src/tool/UIE/UIE.vcxproj
@@ -61,7 +61,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <SupportJustMyCode>true</SupportJustMyCode>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,7 +95,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <ForceConformanceInForLoopScope>false</ForceConformanceInForLoopScope>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/tool/UIE/UIEDoc.cpp
+++ b/src/tool/UIE/UIEDoc.cpp
@@ -381,9 +381,8 @@ void CUIEDoc::OnInsertProgress()
 		else pFrm->MessageBox("UV좌표 설정 및 기타 설정을 해야 Progress가 보일 것입니다.");
 		return;
 	}
-	int i;
 	CRect rcRegion;
-	for (i=0; i<CN3UIProgress::NUM_IMAGETYPE; ++i)
+	for (int i=0; i<CN3UIProgress::NUM_IMAGETYPE; ++i)
 	{
 		if (CN3UIProgress::IMAGETYPE_BKGND == i) pUIImage = pUI->GetBkGndImgRef();
 		else if (CN3UIProgress::IMAGETYPE_FRGND == i) pUIImage = pUI->GetFrGndImgRef();
@@ -670,9 +669,8 @@ BOOL CUIEDoc::SetTrackBarInfos(CN3UITrackBar* pUI)
 	char* szImageTypeNames[2] = {szNames[0], szNames[1]};
 	dlg.SetImageTypes(2, szImageTypeNames);
 	if (IDCANCEL == dlg.DoModal())	return FALSE;
-	int i;
 	CRect rcRegion;
-	for (i=0; i<CN3UITrackBar::NUM_IMAGETYPE; ++i)
+	for (int i=0; i<CN3UITrackBar::NUM_IMAGETYPE; ++i)
 	{
 		if (CN3UITrackBar::IMAGETYPE_BKGND == i) pUIImage = pUI->GetBkGndImgRef();
 		else if (CN3UITrackBar::IMAGETYPE_THUMB == i) pUIImage = pUI->GetThumbImgRef();
@@ -713,9 +711,8 @@ BOOL CUIEDoc::SetButtonInfos(CN3UIButton* pUI)
 	char* szImageTypeNames[4] = {szNames[0], szNames[1], szNames[2], szNames[3]};
 	dlg.SetImageTypes(4, szImageTypeNames);
 	if (IDCANCEL == dlg.DoModal()) return FALSE;
-	int i;
 	CRect rcRegion;
-	for (i=0; i<CN3UIButton::NUM_BTN_STATE; ++i)
+	for (int i=0; i<CN3UIButton::NUM_BTN_STATE; ++i)
 	{
 		pUIImage = pUI->GetImageRef((CN3UIButton::eBTN_STATE)i);
 		ASSERT(pUIImage);
@@ -898,7 +895,8 @@ void CUIEDoc::OnEditMakeGroup()
 	CN3UIBase* pUIFirst = NULL;
 	it_UI it = m_SelectedUIs.begin(), itEnd = m_SelectedUIs.end();
 	bool bOverLapped = false;
-	for(int iUIC = 0; it != itEnd; it++, iUIC++)
+	int iUIC = 0;
+	for(; it != itEnd; it++, iUIC++)
 	{
 		pUI = *it;
 		if(iUIC == iUIC) pUIFirst = pUI;


### PR DESCRIPTION
### Description

I used the following regex pattern to find them:
I used the following regex pattern to find them:
`(for\s*\(\s*(i|j)\s*=)|(\s*int\s*(i|j)\s*;)`
or `i|j|k|m|n|l|o|p|x|z` (case sensitive & full word) to highlight them while modifying the code.

Note that this was done with extra cautious, because there were some instances
where it was obviously necessary for the variable to be outside if it's
being accessed in another usage.
Other instances were not modified, as they flow of the function with
goto functions was too hectic to change. Mostly noticed through the
server codebase, where the engineers coded as if we're doing C in C++.