### PR TITLE
Fix bad usages of std::vector buffers.

### DIFF
--- a/src/engine/N3Base/N3AnimControl.h
+++ b/src/engine/N3Base/N3AnimControl.h
@@ -95,7 +95,7 @@ public:
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL > 0)
 		{
-			std::vector<char> buffer(nL+1, NULL);
+			std::vector<char> buffer(nL, 0);
 			ReadFile(hFile, &buffer[0], nL, &dwRWC, NULL);
 			szName = std::string(buffer.begin(), buffer.end());
 		}

--- a/src/engine/N3Base/N3BaseFileAccess.cpp
+++ b/src/engine/N3Base/N3BaseFileAccess.cpp
@@ -47,7 +47,7 @@ bool CN3BaseFileAccess::Load(HANDLE hFile)
 	ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 	if(nL > 0) 
 	{
-		std::vector<char> buffer(nL+1, NULL);
+		std::vector<char> buffer(nL, 0);
 		ReadFile(hFile, &buffer[0], nL, &dwRWC, NULL);
 		m_szName = std::string(buffer.begin(), buffer.end());
 	}

--- a/src/engine/N3Base/N3Eng.cpp
+++ b/src/engine/N3Base/N3Eng.cpp
@@ -599,12 +599,13 @@ bool CN3Eng::RegistryValueGet(HKEY hKey, const std::string& szName, std::string&
 {
 	if(NULL == hKey || szName.empty() || szValue.empty()) return false;
 
-	std::vector<char> buffer(256, NULL);
 
 	DWORD dwType = REG_SZ;
 	DWORD dwBytes = 0;
-	long lStatus = RegQueryValueEx(hKey, szName.c_str(), NULL, &dwType, (BYTE *)&buffer[0], &dwBytes);
-	szValue = std::string(buffer.begin(), buffer.end());
+
+	char buffer[MAX_PATH]{};
+	long lStatus = RegQueryValueEx(hKey, szName.c_str(), NULL, &dwType, (BYTE *)buffer, &dwBytes);
+	szValue = buffer;
 
 	if(ERROR_SUCCESS == lStatus) return true;
 	return false;

--- a/src/engine/N3Base/N3SkyMng.h
+++ b/src/engine/N3Base/N3SkyMng.h
@@ -69,7 +69,7 @@ struct		__SKY_DAYCHANGE
 		ReadFile(hFile, &nL, 4, &dwRWC, NULL);
 		if(nL > 0) 
 		{
-			std::vector<char> buffer(nL+1, NULL);
+			std::vector<char> buffer(nL, 0);
 			ReadFile(hFile, &buffer[0], nL, &dwRWC, NULL);
 			szName = std::string(buffer.begin(), buffer.end());
 		}

--- a/src/engine/N3Base/N3UIBase.cpp
+++ b/src/engine/N3Base/N3UIBase.cpp
@@ -257,7 +257,7 @@ bool CN3UIBase::Load(HANDLE hFile)
 	ReadFile(hFile, &iIDLen, sizeof(iIDLen), &dwRWC, NULL);				// ui id length
 	if (iIDLen>0)
 	{
-		std::vector<char> buffer(iIDLen+1, NULL);
+		std::vector<char> buffer(iIDLen, 0);
 		ReadFile(hFile, &buffer[0], iIDLen, &dwRWC, NULL);			// ui id
 		m_szID = std::string(buffer.begin(), buffer.end());
 	}
@@ -274,7 +274,7 @@ bool CN3UIBase::Load(HANDLE hFile)
 	ReadFile(hFile, &iTooltipLen, sizeof(iTooltipLen), &dwRWC, NULL);		//	tooltip문자열 길이
 	if (iTooltipLen>0)
 	{
-		std::vector<char> buffer(iTooltipLen+1, NULL);
+		std::vector<char> buffer(iTooltipLen, 0);
 		ReadFile(hFile, &buffer[0], iTooltipLen, &dwRWC, NULL);
 		m_szToolTip = std::string(buffer.begin(), buffer.end());
 	}
@@ -284,7 +284,7 @@ bool CN3UIBase::Load(HANDLE hFile)
 	ReadFile(hFile, &iSndFNLen, sizeof(iSndFNLen), &dwRWC, NULL);		//	사운드 파일 문자열 길이
 	if (iSndFNLen>0)
 	{
-		std::vector<char> buffer(iSndFNLen+1, NULL);
+		std::vector<char> buffer(iSndFNLen, 0);
 		ReadFile(hFile, &buffer[0], iSndFNLen, &dwRWC, NULL);
 
 		__ASSERT(NULL == m_pSnd_OpenUI, "memory leak");
@@ -294,7 +294,7 @@ bool CN3UIBase::Load(HANDLE hFile)
 	ReadFile(hFile, &iSndFNLen, sizeof(iSndFNLen), &dwRWC, NULL);		//	사운드 파일 문자열 길이
 	if (iSndFNLen>0)
 	{
-		std::vector<char> buffer(iSndFNLen+1, NULL);
+		std::vector<char> buffer(iSndFNLen, 0);
 		ReadFile(hFile, &buffer[0], iSndFNLen, &dwRWC, NULL);
 
 		__ASSERT(NULL == m_pSnd_CloseUI, "memory leak");

--- a/src/engine/N3Base/N3UIButton.cpp
+++ b/src/engine/N3Base/N3UIButton.cpp
@@ -266,7 +266,7 @@ bool CN3UIButton::Load(HANDLE hFile)
 	ReadFile(hFile, &iSndFNLen, sizeof(iSndFNLen), &dwNum, NULL);		//	사운드 파일 문자열 길이
 	if (iSndFNLen>0)
 	{
-		std::vector<char> buffer(iSndFNLen+1, NULL);
+		std::vector<char> buffer(iSndFNLen, 0);
 		ReadFile(hFile, &buffer[0], iSndFNLen, &dwNum, NULL);
 
 		__ASSERT(NULL == m_pSnd_On, "memory leak");
@@ -276,7 +276,7 @@ bool CN3UIButton::Load(HANDLE hFile)
 	ReadFile(hFile, &iSndFNLen, sizeof(iSndFNLen), &dwNum, NULL);		//	사운드 파일 문자열 길이
 	if (iSndFNLen>0)
 	{
-		std::vector<char> buffer(iSndFNLen+1, NULL);
+		std::vector<char> buffer(iSndFNLen, 0);
 		ReadFile(hFile, &buffer[0], iSndFNLen, &dwNum, NULL);
 
 		__ASSERT(NULL == m_pSnd_Click, "memory leak");

--- a/src/engine/N3Base/N3UIEdit.cpp
+++ b/src/engine/N3Base/N3UIEdit.cpp
@@ -677,7 +677,7 @@ bool CN3UIEdit::Load(HANDLE hFile)
 	ReadFile(hFile, &iSndFNLen, sizeof(iSndFNLen), &dwNum, NULL);		//	사운드 파일 문자열 길이
 	if (iSndFNLen>0)
 	{
-		std::vector<char> buffer(iSndFNLen+1, NULL);
+		std::vector<char> buffer(iSndFNLen, 0);
 		ReadFile(hFile, &buffer[0], iSndFNLen, &dwNum, NULL);
 
 		__ASSERT(NULL == m_pSnd_Typing, "memory leak");

--- a/src/engine/N3Base/N3UIStatic.cpp
+++ b/src/engine/N3Base/N3UIStatic.cpp
@@ -80,7 +80,7 @@ bool CN3UIStatic::Load(HANDLE hFile)
 	ReadFile(hFile, &iSndFNLen, sizeof(iSndFNLen), &dwNum, NULL);		//	사운드 파일 문자열 길이
 	if (iSndFNLen>0)
 	{
-		std::vector<char> buffer(iSndFNLen+1, NULL);
+		std::vector<char> buffer(iSndFNLen, 0);
 		ReadFile(hFile, &buffer[0], iSndFNLen, &dwNum, NULL);
 
 		__ASSERT(NULL == m_pSnd_Click, "memory leak");

--- a/src/game/GameBase.cpp
+++ b/src/game/GameBase.cpp
@@ -397,18 +397,18 @@ e_ItemType CGameBase::MakeResrcFileNameForUPC(	__TABLE_ITEM_BASIC* pItem,		// 아
 		__ASSERT(0, "Invalid Item Position");
 	}
 
-	std::vector<char> buffer(256, NULL);
+	char buffer[MAX_PATH]{};
 	if(pszResrcFN)
 	{
 		if(pItem->dwIDResrc) 
 		{
-			sprintf(&buffer[0],	"Item\\%.1d_%.4d_%.2d_%.1d%s",
+			sprintf(buffer,	"Item\\%.1d_%.4d_%.2d_%.1d%s",
 				(pItem->dwIDResrc / 10000000), 
 				(pItem->dwIDResrc / 1000) % 10000, 
 				(pItem->dwIDResrc / 10) % 100, 
 				pItem->dwIDResrc % 10,
 				szExt.c_str());
-			*pszResrcFN = &buffer[0];
+			*pszResrcFN = buffer;
 		}
 		else // 아이콘만 있는 플러그나 파트 일수도 있다...
 		{
@@ -417,13 +417,13 @@ e_ItemType CGameBase::MakeResrcFileNameForUPC(	__TABLE_ITEM_BASIC* pItem,		// 아
 	}
 	if(pszIconFN)
 	{
-//		sprintf(&buffer[0],	"UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt", eType, iIndex, eRace, iPos);
-		sprintf(&buffer[0],	"UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt",
+//		sprintf(buffer,	"UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt", eType, iIndex, eRace, iPos);
+		sprintf(buffer,	"UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt",
 			(pItem->dwIDIcon / 10000000), 
 			(pItem->dwIDIcon / 1000) % 10000, 
 			(pItem->dwIDIcon / 10) % 100, 
 			pItem->dwIDIcon % 10);
-		*pszIconFN = &buffer[0];
+		*pszIconFN = buffer;
 	}
 	
 	return eType;

--- a/src/game/UIHotKeyDlg.cpp
+++ b/src/game/UIHotKeyDlg.cpp
@@ -403,9 +403,9 @@ void CUIHotKeyDlg::InitIconUpdate()
 			spSkill->pSkill = pUSkill;
 
 			// 아이콘 이름 만들기.. ^^
-			std::vector<char> buffer(256, NULL);
-			sprintf(&buffer[0],	"UI\\skillicon_%.2d_%d.dxt", HD.iID%100, HD.iID/100);
-			spSkill->szIconFN = std::string(buffer.begin(), buffer.end());
+			char buffer[MAX_PATH]{};
+			sprintf(buffer,	"UI\\skillicon_%.2d_%d.dxt", HD.iID%100, HD.iID/100);
+			spSkill->szIconFN = buffer;
 
 			// 아이콘 로드하기.. ^^
 			spSkill->pUIIcon = new CN3UIIcon;
@@ -877,9 +877,9 @@ bool CUIHotKeyDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 		spSkill->pSkill = pUSkill;
 
 		// 아이콘 이름 만들기.. ^^
-		std::vector<char> buffer(256, NULL);
-		sprintf(&buffer[0],	"UI\\skillicon_%.2d_%d.dxt", spItem->pItemBasic->dwEffectID1%100, spItem->pItemBasic->dwEffectID1/100);
-		spSkill->szIconFN = std::string(buffer.begin(), buffer.end());
+		char buffer[MAX_PATH]{};
+		sprintf(buffer,	"UI\\skillicon_%.2d_%d.dxt", spItem->pItemBasic->dwEffectID1%100, spItem->pItemBasic->dwEffectID1/100);
+		spSkill->szIconFN = buffer;
 
 		// 아이콘 로드하기.. ^^
 		spSkill->pUIIcon = new CN3UIIcon;

--- a/src/game/UISkillTreeDlg.cpp
+++ b/src/game/UISkillTreeDlg.cpp
@@ -1315,9 +1315,9 @@ stop:
 	spSkill->pSkill = pUSkill;
 
 	// 아이콘 이름 만들기.. ^^
-	std::vector<char> buffer(256, NULL);
-	sprintf(&buffer[0],	"UI\\skillicon_%.2d_%d.dxt", pUSkill->dwID%100, pUSkill->dwID/100);
-	spSkill->szIconFN = std::string(buffer.begin(), buffer.end());
+	char buffer[MAX_PATH]{};
+	sprintf(buffer,	"UI\\skillicon_%.2d_%d.dxt", pUSkill->dwID%100, pUSkill->dwID/100);
+	spSkill->szIconFN = buffer;
 
 	// 아이콘 로드하기.. ^^
 	spSkill->pUIIcon = new CN3UIIcon;

--- a/src/game/UIStateBar.cpp
+++ b/src/game/UIStateBar.cpp
@@ -526,8 +526,10 @@ bool CUIStateBar::ToggleMiniMap()
 
 void CUIStateBar::AddMagic(__TABLE_UPC_SKILL* pSkill, float fDuration)
 {
-	std::vector<char> buffer(256, NULL);
-	sprintf(&buffer[0],	"UI\\skillicon_%.2d_%d.dxt", pSkill->dwID%100, pSkill->dwID/100);
+	// TODO: Change instances like these to std::format once upgrading to cpp20:
+	// https://en.cppreference.com/w/cpp/utility/format/format
+	char buffer[MAX_PATH]{};
+	sprintf(buffer,	"UI\\skillicon_%.2d_%d.dxt", pSkill->dwID%100, pSkill->dwID/100);
 
 	__DurationMagicImg* pMagicImg = new __DurationMagicImg;
 	pMagicImg->fDuration = fDuration;
@@ -536,7 +538,7 @@ void CUIStateBar::AddMagic(__TABLE_UPC_SKILL* pSkill, float fDuration)
 
 	CN3UIDBCLButton* pIcon = pMagicImg->pIcon;
 	pIcon->Init(this);
-	pIcon->SetTex(std::string(buffer.begin(), buffer.end()));
+	pIcon->SetTex(buffer);
 	pIcon->SetTooltipText(pSkill->szName.c_str());
 	pIcon->SetUVRect(0,0,1,1);
 
@@ -561,8 +563,8 @@ void CUIStateBar::AddMagic(__TABLE_UPC_SKILL* pSkill, float fDuration)
 
 void CUIStateBar::DelMagic(__TABLE_UPC_SKILL* pSkill)
 {
-	std::vector<char> buffer(256, NULL);
-	sprintf(&buffer[0],	"UI\\skillicon_%.2d_%d.dxt", pSkill->dwID%100, pSkill->dwID/100);
+	char buffer[MAX_PATH]{};
+	sprintf(buffer,	"UI\\skillicon_%.2d_%d.dxt", pSkill->dwID%100, pSkill->dwID/100);
 
 	it_MagicImg it, ite, itRemove;
 	itRemove = ite = m_pMagic.end();	
@@ -571,7 +573,7 @@ void CUIStateBar::DelMagic(__TABLE_UPC_SKILL* pSkill)
 		__DurationMagicImg* pMagicImg = (*it);
 		CN3UIDBCLButton* pIcon = pMagicImg->pIcon;
 		CN3Texture* pTex = pIcon->GetTex();
-		if(pTex && lstrcmpi(pTex->FileName().c_str(), (const char *)&buffer[0])==0)
+		if(pTex && lstrcmpi(pTex->FileName().c_str(), buffer)==0)
 		{
 			itRemove = it;
 		}

--- a/src/tool/N3Indoor/OrganizeView.cpp
+++ b/src/tool/N3Indoor/OrganizeView.cpp
@@ -594,13 +594,13 @@ void COrganizeView::RefreshLinkedList()
 	int iCount = m_LinkedListCtrl.GetItemCount();		
 
 	ShapeInfo* pSI;
-	std::vector<char> buffer(32, NULL);
+	char buffer[32]{};
 	siiter siit = pVol->m_plShapeInfoList.begin();
 	while(siit != pVol->m_plShapeInfoList.end())
 	{
 		pSI = *siit++;
-		sprintf(&buffer[0], "Shape_%d", pSI->m_iID);
-		str = std::string(buffer.begin(), buffer.end());
+		sprintf(buffer, "Shape_%d", pSI->m_iID);
+		str = buffer;
 		m_LinkedListCtrl.InsertItem(iCount++, str.c_str(), 1);						
 	}
 }
@@ -830,13 +830,13 @@ void COrganizeView::RefreshTotalShape()
 	int iCount = 0;
 	ShapeInfo* pSI;
 	std::string str; 
-	std::vector<char> buffer(32, NULL);
+	char buffer[32]{};
 	siiter siit = m_PVSMgr.m_plShapeInfoList.begin();
 	while(siit != m_PVSMgr.m_plShapeInfoList.end())
 	{
 		pSI = *siit++;
-		sprintf(&buffer[0], "Part_%d", pSI->m_iID);
-		str = std::string(buffer.begin(), buffer.end());
+		sprintf(buffer, "Part_%d", pSI->m_iID);
+		str = buffer;
 		m_ShapesListCtrl.InsertItem(iCount++, str.c_str(), 1);						
 	}
 }

--- a/src/tool/N3Indoor/PortalFactory.cpp
+++ b/src/tool/N3Indoor/PortalFactory.cpp
@@ -32,9 +32,9 @@ CPortalFactory::~CPortalFactory()
 
 std::string	CPortalFactory::MakePvsVolString(int iIndex)
 {
-	std::vector<char> buffer(32, NULL);
-	sprintf(&buffer[0], "Vol_%d", iIndex);
-	return std::string(buffer.begin(), buffer.end());
+	char buffer[32]{};
+	sprintf(buffer, "Vol_%d", iIndex);
+	return std::string(buffer);
 }
 
 CPortalVolume* CPortalFactory::CreatePvsVol(int iIndex)

--- a/src/tool/N3Indoor/PvsObjFactory.cpp
+++ b/src/tool/N3Indoor/PvsObjFactory.cpp
@@ -80,10 +80,9 @@ HICON CPvsObjFactory::GetPvsWallIcon()
 std::string	CPvsObjFactory::MakePvsWallString(int iIndex, e_WallType eWT)
 {
 	int iWT = (int)eWT; iWT++;
-	std::vector<char> buffer(32, NULL);
-	sprintf(&buffer[0], "Wall_%d_%d", iIndex, iWT);
-
-	return std::string(buffer.begin(), buffer.end());
+	char buffer[32]{};
+	sprintf(buffer, "Wall_%d_%d", iIndex, iWT);
+	return std::string(buffer);
 }
 
 HICON CPvsObjFactory::GetPvsVolIcon()
@@ -93,10 +92,9 @@ HICON CPvsObjFactory::GetPvsVolIcon()
 
 std::string	CPvsObjFactory::MakePvsVolString(int iIndex)
 {
-	std::vector<char> buffer(32, NULL);
-	sprintf(&buffer[0], "Vol_%d", iIndex);
-
-	return std::string(buffer.begin(), buffer.end());
+	char buffer[32]{};
+	sprintf(buffer, "Vol_%d", iIndex);
+	return std::string(buffer);
 }
 
 


### PR DESCRIPTION
### Description

Note that there is no need to use std::vector<char> as buffers when the
size is known as a constant value.
If the size is known, use standard arrays to reduce waste of resources.
This change also fixes an issue where some buffers had size + 1, because
we use begin and end, there is no need to account for the null
termination, since the std::string constructor will already add it.